### PR TITLE
Font handling improvements

### DIFF
--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -747,7 +747,11 @@ void REFramework::update_fonts() {
             ranges = font.ranges.data();
         }
 
-        font.font = fonts->AddFontFromFileTTF(font.filepath.string().c_str(), (float)font.size, nullptr, ranges);
+        if (fs::exists(font.filepath)) {
+            font.font = fonts->AddFontFromFileTTF(font.filepath.string().c_str(), (float)font.size, nullptr, ranges);
+        } else {
+            font.font = fonts->AddFontFromMemoryCompressedTTF(RobotoMedium_compressed_data, RobotoMedium_compressed_size, (float)font.size, nullptr, ranges);
+        }
     }
 
     fonts->Build();

--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -712,6 +712,21 @@ void REFramework::consume_input() {
     m_accumulated_mouse_delta[1] = 0.0f;
 }
 
+int REFramework::add_font(const std::filesystem::path& filepath, int size, const std::vector<ImWchar>& ranges) {
+    // Look for a font already matching this description.
+    for (int i = 0; i < m_additional_fonts.size(); ++i) {
+        const auto& font = m_additional_fonts[i];
+
+        if (font.filepath == filepath && font.size == size && font.ranges == ranges) {
+            return i;
+        }
+    }
+
+    m_additional_fonts.emplace_back(filepath, size, ranges, nullptr);
+
+    return m_additional_fonts.size() - 1;
+}
+
 void REFramework::update_fonts() {
     if (m_font_size == m_font_desired_size) {
         return;
@@ -722,6 +737,17 @@ void REFramework::update_fonts() {
 
     fonts->Clear();
     fonts->AddFontFromMemoryCompressedTTF(RobotoMedium_compressed_data, RobotoMedium_compressed_size, (float)m_font_size);
+
+    for (auto& font : m_additional_fonts) {
+        const ImWchar* ranges = nullptr;
+
+        if (!font.ranges.empty()) {
+            ranges = font.ranges.data();
+        }
+
+        font.font = fonts->AddFontFromFileTTF(font.filepath.string().c_str(), (float)font.size, nullptr, ranges);
+    }
+
     fonts->Build();
 
     if (m_renderer_type == RendererType::D3D11) {

--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -369,6 +369,7 @@ void REFramework::on_frame_d3d11() {
     }
 
     consume_input();
+    update_fonts();
 
     ImGui_ImplDX11_NewFrame();
     ImGui_ImplWin32_NewFrame();
@@ -464,6 +465,7 @@ void REFramework::on_frame_d3d12() {
     }
 
     consume_input();
+    update_fonts();
 
     ImGui_ImplDX12_NewFrame();
     ImGui_ImplWin32_NewFrame();
@@ -710,6 +712,25 @@ void REFramework::consume_input() {
     m_accumulated_mouse_delta[1] = 0.0f;
 }
 
+void REFramework::update_fonts() {
+    if (m_font_size == m_font_desired_size) {
+        return;
+    }
+
+    m_font_size = m_font_desired_size;
+    auto& fonts = ImGui::GetIO().Fonts;
+
+    fonts->Clear();
+    fonts->AddFontFromMemoryCompressedTTF(RobotoMedium_compressed_data, RobotoMedium_compressed_size, (float)m_font_size);
+    fonts->Build();
+
+    if (m_renderer_type == RendererType::D3D11) {
+        ImGui_ImplDX11_InvalidateDeviceObjects();
+    } else if (m_renderer_type == RendererType::D3D12) {
+        ImGui_ImplDX12_InvalidateDeviceObjects();
+    }
+}
+
 void REFramework::draw_ui() {
     std::lock_guard _{m_input_mutex};
 
@@ -900,8 +921,7 @@ void REFramework::set_imgui_style() noexcept {
     colors[ImGuiCol_TitleBgCollapsed] = ImVec4{0.25f, 0.2505f, 0.251f, 1.0f};
 
     // Font
-    auto& io = ImGui::GetIO();
-    io.Fonts->AddFontFromMemoryCompressedTTF(RobotoMedium_compressed_data, RobotoMedium_compressed_size, 16.0f);
+    set_font_size(16);
 }
 
 bool REFramework::initialize() {

--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -723,16 +723,18 @@ int REFramework::add_font(const std::filesystem::path& filepath, int size, const
     }
 
     m_additional_fonts.emplace_back(filepath, size, ranges, nullptr);
+    m_fonts_need_updating = true;
 
     return m_additional_fonts.size() - 1;
 }
 
 void REFramework::update_fonts() {
-    if (m_font_size == m_font_desired_size) {
+    if (!m_fonts_need_updating) {
         return;
     }
 
-    m_font_size = m_font_desired_size;
+    m_fonts_need_updating = false;
+
     auto& fonts = ImGui::GetIO().Fonts;
 
     fonts->Clear();

--- a/src/REFramework.hpp
+++ b/src/REFramework.hpp
@@ -97,9 +97,17 @@ public:
         return m_hook_monitor_mutex;
     }
 
-    void set_font_size(int size) { m_font_desired_size = size; }
-    auto get_font_size() const { return m_font_desired_size; }
+    void set_font_size(int size) { 
+        if (m_font_size != size) {
+            m_font_size = size;
+            m_fonts_need_updating = true;
+        }
+    }
+
+    auto get_font_size() const { return m_font_size; }
+
     int add_font(const std::filesystem::path& filepath, int size, const std::vector<ImWchar>& ranges = {});
+
     ImFont* get_font(int index) const {
         if (index >= 0 && index < m_additional_fonts.size()) {
             return m_additional_fonts[index].font;
@@ -144,9 +152,6 @@ private:
     ImVec2 m_last_window_pos{};
     ImVec2 m_last_window_size{};
 
-    int m_font_size{};
-    int m_font_desired_size{16};
-
     struct AdditionalFont {
         std::filesystem::path filepath{};
         int size{16};
@@ -154,6 +159,8 @@ private:
         ImFont* font{};
     };
 
+    bool m_fonts_need_updating{true};
+    int m_font_size{16};
     std::vector<AdditionalFont> m_additional_fonts{};
 
     std::mutex m_input_mutex{};

--- a/src/REFramework.hpp
+++ b/src/REFramework.hpp
@@ -96,8 +96,11 @@ public:
         return m_hook_monitor_mutex;
     }
 
+    void set_font_size(int size) { m_font_desired_size = size; }
+
 private:
     void consume_input();
+    void update_fonts();
 
     void draw_ui();
     void draw_about();
@@ -130,6 +133,9 @@ private:
     
     ImVec2 m_last_window_pos{};
     ImVec2 m_last_window_size{};
+
+    int m_font_size{};
+    int m_font_desired_size{16};
 
     std::mutex m_input_mutex{};
     std::recursive_mutex m_config_mtx{};

--- a/src/REFramework.hpp
+++ b/src/REFramework.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <unordered_set>
+#include <filesystem>
 
 #include <spdlog/spdlog.h>
 #include <imgui.h>
@@ -97,6 +98,15 @@ public:
     }
 
     void set_font_size(int size) { m_font_desired_size = size; }
+    auto get_font_size() const { return m_font_desired_size; }
+    int add_font(const std::filesystem::path& filepath, int size, const std::vector<ImWchar>& ranges = {});
+    ImFont* get_font(int index) const {
+        if (index >= 0 && index < m_additional_fonts.size()) {
+            return m_additional_fonts[index].font;
+        } else {
+            return nullptr;
+        }
+    }
 
 private:
     void consume_input();
@@ -136,6 +146,15 @@ private:
 
     int m_font_size{};
     int m_font_desired_size{16};
+
+    struct AdditionalFont {
+        std::filesystem::path filepath{};
+        int size{16};
+        std::vector<ImWchar> ranges{};
+        ImFont* font{};
+    };
+
+    std::vector<AdditionalFont> m_additional_fonts{};
 
     std::mutex m_input_mutex{};
     std::recursive_mutex m_config_mtx{};

--- a/src/mods/REFrameworkConfig.cpp
+++ b/src/mods/REFrameworkConfig.cpp
@@ -1,3 +1,5 @@
+#include "../REFramework.hpp"
+
 #include "REFrameworkConfig.hpp"
 
 std::shared_ptr<REFrameworkConfig>& REFrameworkConfig::get() {
@@ -19,6 +21,10 @@ void REFrameworkConfig::on_draw_ui() {
     m_menu_key->draw("Menu Key");
     m_remember_menu_state->draw("Remember Menu Open/Closed State");
 
+    if (m_font_size->draw("Font Size")) {
+        g_framework->set_font_size(m_font_size->value());
+    }
+
     ImGui::TreePop();
 }
 
@@ -30,6 +36,8 @@ void REFrameworkConfig::on_config_load(const utility::Config& cfg) {
     if (m_remember_menu_state->value()) {
         g_framework->set_draw_ui(m_menu_open->value(), false);
     }
+    
+    g_framework->set_font_size(m_font_size->value());
 }
 
 void REFrameworkConfig::on_config_save(utility::Config& cfg) {

--- a/src/mods/REFrameworkConfig.hpp
+++ b/src/mods/REFrameworkConfig.hpp
@@ -28,10 +28,12 @@ private:
     ModKey::Ptr m_menu_key{ ModKey::create(generate_name("MenuKey"), DIK_INSERT) };
     ModToggle::Ptr m_menu_open{ ModToggle::create(generate_name("MenuOpen"), true) };
     ModToggle::Ptr m_remember_menu_state{ ModToggle::create(generate_name("RememberMenuState"), false) };
+    ModInt32::Ptr m_font_size{ModInt32::create(generate_name("FontSize"), 16)};
 
     ValueList m_options {
         *m_menu_key,
         *m_menu_open,
-        *m_remember_menu_state
+        *m_remember_menu_state,
+        *m_font_size,
     };
 };

--- a/src/mods/bindings/ImGui.cpp
+++ b/src/mods/bindings/ImGui.cpp
@@ -352,6 +352,39 @@ void new_line() {
 bool collapsing_header(const char* name) {
     return ImGui::CollapsingHeader(name);
 }
+
+int load_font(const char* filepath, int size, sol::object ranges) {
+    namespace fs = std::filesystem;
+
+    std::string modpath{};
+
+    modpath.resize(1024, 0);
+    modpath.resize(GetModuleFileName(nullptr, modpath.data(), modpath.size()));
+
+    auto fonts_path = fs::path{modpath}.parent_path() / "reframework" / "fonts";
+    auto font_path = fonts_path / filepath;
+
+    fs::create_directories(fonts_path);
+    std::vector<ImWchar> ranges_vec{};
+
+    if (ranges.is<sol::table>()) {
+        sol::table ranges_table = ranges;
+
+        for (auto i = 1u; i <= ranges_table.size(); ++i) {
+            ranges_vec.push_back(ranges_table[i].get<ImWchar>());
+        }
+    }
+
+    return g_framework->add_font(font_path, size, ranges_vec);
+}
+
+void push_font(int font) {
+    ImGui::PushFont(g_framework->get_font(font));
+}
+
+void pop_font() {
+    ImGui::PopFont();
+}
 } // namespace api::imgui
 
 namespace api::draw {
@@ -502,6 +535,9 @@ void bindings::open_imgui(ScriptState* s) {
     imgui["spacing"] = api::imgui::spacing;
     imgui["new_line"] = api::imgui::new_line;
     imgui["collapsing_header"] = api::imgui::collapsing_header;
+    imgui["load_font"] = api::imgui::load_font;
+    imgui["push_font"] = api::imgui::push_font;
+    imgui["pop_font"] = api::imgui::pop_font;
     lua["imgui"] = imgui;
 
     auto draw = lua.create_table();

--- a/src/mods/bindings/ImGui.cpp
+++ b/src/mods/bindings/ImGui.cpp
@@ -2,6 +2,7 @@
 
 #include "../ScriptRunner.hpp"
 #include "../../sdk/SceneManager.hpp"
+#include "REFramework.hpp"
 
 #include "ImGui.hpp"
 
@@ -385,6 +386,10 @@ void push_font(int font) {
 void pop_font() {
     ImGui::PopFont();
 }
+
+int get_default_font_size() {
+    return g_framework->get_font_size();
+}
 } // namespace api::imgui
 
 namespace api::draw {
@@ -538,6 +543,7 @@ void bindings::open_imgui(ScriptState* s) {
     imgui["load_font"] = api::imgui::load_font;
     imgui["push_font"] = api::imgui::push_font;
     imgui["pop_font"] = api::imgui::pop_font;
+    imgui["get_default_font_size"] = api::imgui::get_default_font_size;
     lua["imgui"] = imgui;
 
     auto draw = lua.create_table();

--- a/src/mods/bindings/ImGui.cpp
+++ b/src/mods/bindings/ImGui.cpp
@@ -354,8 +354,13 @@ bool collapsing_header(const char* name) {
     return ImGui::CollapsingHeader(name);
 }
 
-int load_font(const char* filepath, int size, sol::object ranges) {
+int load_font(sol::object filepath_obj, int size, sol::object ranges) {
     namespace fs = std::filesystem;
+    const char* filepath = "doesnt-exist.not-a-real-font";
+
+    if (filepath_obj.is<const char*>()) {
+        filepath = filepath_obj.as<const char*>();
+    }
 
     std::string modpath{};
 


### PR DESCRIPTION
This PR allows users to configure the size of the default font in REFramework. It will eventually include a scripting API to load custom fonts and support different character ranges so languages such as Japanese and Chinese can be supported.