### PR TITLE
Add optional font_size parameter to draw.text api

### DIFF
--- a/src/mods/bindings/ImGui.cpp
+++ b/src/mods/bindings/ImGui.cpp
@@ -405,8 +405,11 @@ void world_text(const char* text, sol::object world_pos_object, ImU32 color = 0x
     draw_list->AddText(ImVec2{screen_pos->x, screen_pos->y}, color, text);
 }
 
-void text(const char* text, float x, float y, ImU32 color) {
-    ImGui::GetBackgroundDrawList()->AddText(ImVec2{x, y}, color, text);
+void text(const char* text, float x, float y, ImU32 color, float font_size = 0.0f) {
+    if (font_size > 0.0f)
+        ImGui::GetBackgroundDrawList()->AddText(NULL, font_size, ImVec2{x, y}, color, text);
+    else
+        ImGui::GetBackgroundDrawList()->AddText(ImVec2{x, y}, color, text);
 }
 
 void filled_rect(float x, float y, float w, float h, ImU32 color) {

--- a/src/mods/bindings/ImGui.cpp
+++ b/src/mods/bindings/ImGui.cpp
@@ -406,10 +406,11 @@ void world_text(const char* text, sol::object world_pos_object, ImU32 color = 0x
 }
 
 void text(const char* text, float x, float y, ImU32 color, float font_size = 0.0f) {
-    if (font_size > 0.0f)
+    if (font_size > 0.0f) {
         ImGui::GetBackgroundDrawList()->AddText(NULL, font_size, ImVec2{x, y}, color, text);
-    else
+    } else {
         ImGui::GetBackgroundDrawList()->AddText(ImVec2{x, y}, color, text);
+    }
 }
 
 void filled_rect(float x, float y, float w, float h, ImU32 color) {


### PR DESCRIPTION
This PR adds an optional parameter "font_size" to the draw.text api call.
This will allow for better readability on high resolution screens.