### PR TITLE
Added is_drawing_ui function to the plugin API

### DIFF
--- a/include/reframework/API.h
+++ b/include/reframework/API.h
@@ -67,6 +67,7 @@ typedef struct {
     void (*log_error)(const char* format, ...);
     void (*log_warn)(const char* format, ...);
     void (*log_info)(const char* format, ...);
+    bool (*is_drawing_ui)();
 } REFrameworkPluginFunctions;
 
 typedef struct {
@@ -86,6 +87,7 @@ DECLARE_REFRAMEWORK_HANDLE(REFrameworkFieldHandle);
 DECLARE_REFRAMEWORK_HANDLE(REFrameworkPropertyHandle);
 DECLARE_REFRAMEWORK_HANDLE(REFrameworkManagedObjectHandle);
 DECLARE_REFRAMEWORK_HANDLE(REFrameworkTDBHandle);
+DECLARE_REFRAMEWORK_HANDLE(REFrameworkHandle);
 DECLARE_REFRAMEWORK_HANDLE(REFrameworkResourceHandle);
 DECLARE_REFRAMEWORK_HANDLE(REFrameworkResourceManagerHandle);
 DECLARE_REFRAMEWORK_HANDLE(REFrameworkVMContextHandle);

--- a/include/reframework/API.hpp
+++ b/include/reframework/API.hpp
@@ -110,6 +110,10 @@ public:
         return (ResourceManager*)sdk()->functions->get_resource_manager();
     }
 
+    inline const auto reframework() const {
+        return (REFramework*)param()->functions;
+    }
+
     void lock_lua() {
         m_lua_mtx.lock();
         m_param->functions->lock_lua();
@@ -252,6 +256,16 @@ public:
 
         API::Property* get_property(uint32_t index) const {
             return (API::Property*)API::s_instance->sdk()->tdb->get_property(*this, index);
+        }
+    };
+
+    struct REFramework {
+        operator ::REFrameworkHandle() {
+            return (::REFrameworkHandle)this;
+        }
+
+        bool is_drawing_ui() const {
+            return API::s_instance->param()->functions->is_drawing_ui();
         }
     };
 

--- a/src/mods/PluginLoader.cpp
+++ b/src/mods/PluginLoader.cpp
@@ -46,9 +46,12 @@ void log_info(const char* format, ...) {
     va_end(args);
     spdlog::info("[Plugin] {}", str);
 }
+bool is_drawing_ui() {
+    return g_framework->is_drawing_ui();
+}
 }
 
-REFrameworkPluginFunctions g_plugin_functions{
+REFrameworkPluginFunctions g_plugin_functions {
     reframework_on_lua_state_created,
     reframework_on_lua_state_destroyed,
     reframework_on_present,
@@ -61,6 +64,7 @@ REFrameworkPluginFunctions g_plugin_functions{
     reframework::log_error,
     reframework::log_warn,
     reframework::log_info,
+    reframework::is_drawing_ui
 };
 
 REFrameworkSDKFunctions g_sdk_functions {


### PR DESCRIPTION
Added ability to check if REFramework is being drawn using the plugin API. Accessed as follows:
```cpp
API::get()->reframework()->is_drawing_ui()
```