### PR TITLE
Added new get_runtime_type method to Plugin API

### DIFF
--- a/include/reframework/API.h
+++ b/include/reframework/API.h
@@ -7,7 +7,7 @@
 #endif
 
 #define REFRAMEWORK_PLUGIN_VERSION_MAJOR 1
-#define REFRAMEWORK_PLUGIN_VERSION_MINOR 2
+#define REFRAMEWORK_PLUGIN_VERSION_MINOR 3
 #define REFRAMEWORK_PLUGIN_VERSION_PATCH 0
 
 #define REFRAMEWORK_RENDERER_D3D11 0
@@ -168,6 +168,7 @@ typedef struct {
     REFrameworkTypeDefinitionHandle (*get_underlying_type)(REFrameworkTypeDefinitionHandle);
 
     REFrameworkTypeInfoHandle (*get_type_info)(REFrameworkTypeDefinitionHandle);
+    REFrameworkManagedObjectHandle (*get_runtime_type)(REFrameworkTypeDefinitionHandle);
 } REFrameworkTDBTypeDefinition;
 
 /*

--- a/include/reframework/API.hpp
+++ b/include/reframework/API.hpp
@@ -437,6 +437,10 @@ public:
         API::TypeInfo* get_type_info() const {
             return (API::TypeInfo*)API::s_instance->sdk()->type_definition->get_type_info(*this);
         }
+
+        API::ManagedObject* get_runtime_type() const {
+            return (API::ManagedObject*)API::s_instance->sdk()->type_definition->get_runtime_type(*this);
+        }
     };
 
     struct Method {

--- a/src/mods/PluginLoader.cpp
+++ b/src/mods/PluginLoader.cpp
@@ -276,7 +276,8 @@ REFrameworkTDBTypeDefinition g_type_definition_data {
     [](REFrameworkTypeDefinitionHandle tdef) { return (REFrameworkTypeDefinitionHandle)RETYPEDEF(tdef)->get_parent_type(); },
     [](REFrameworkTypeDefinitionHandle tdef) { return (REFrameworkTypeDefinitionHandle)RETYPEDEF(tdef)->get_declaring_type(); },
     [](REFrameworkTypeDefinitionHandle tdef) { return (REFrameworkTypeDefinitionHandle)RETYPEDEF(tdef)->get_underlying_type(); },
-    [](REFrameworkTypeDefinitionHandle tdef) { return (REFrameworkTypeInfoHandle)RETYPEDEF(tdef)->get_type(); }
+    [](REFrameworkTypeDefinitionHandle tdef) { return (REFrameworkTypeInfoHandle)RETYPEDEF(tdef)->get_type(); },
+    [](REFrameworkTypeDefinitionHandle tdef) { return (REFrameworkManagedObjectHandle)RETYPEDEF(tdef)->get_runtime_type(); }
 };
 
 #define REMETHOD(var) ((sdk::REMethodDefinition*)var)


### PR DESCRIPTION
I added a new `get_runtime_type` method to `API::TypeDefinition`, because `API::typeof` is kind of bothersome to use. Bumped up the plugin minor version by 1 as well.

Tested and is working as intended.