### PR TITLE
Fix inconsistent crash when opening the Singleton display menu

### DIFF
--- a/shared/sdk/REGlobals.cpp
+++ b/shared/sdk/REGlobals.cpp
@@ -34,6 +34,11 @@ REGlobals::REGlobals() {
     for (auto i = utility::scan(start, end - start, pat); i.has_value(); i = utility::scan(*i + 1, end - (*i + 1), pat)) {
         auto ptr = utility::calculate_absolute(*i + 3);
 
+        // Make sure the global is within the module boundaries
+        if (ptr < start || ptr > (end - 8)) {
+            continue;
+        }
+
         // Make sure the pointer is aligned on an 8-byte boundary.
         if (ptr == 0 || ((uintptr_t)ptr & (sizeof(void*) - 1)) != 0) {
             continue;


### PR DESCRIPTION
At least in Monster Hunter Rise, there is a rather inconsistent crash when opening the Singleton Display menu in the Object Explorer. The crash happens due to an access violation in `REGlobals::refresh_map` (`REGlobals.cpp` Line 221 Post commit).

Without the check I added, sometimes values outside the executable would get added to the object map. This poses 2 possible scenarios:
1. That pointer is mapped during the initialization of `REGlobals`, which causes `IsBadReadPtr` to return false, but later it is unmapped and an Access Violation happens when refreshing the map.
2. The pointer is not mapped at all and `IsBadReadPtr` catches it.

In scenario 1 the game crashes when opening the singleton menu, in scenario 2 it doesn't.

Globals are always stored inside executable memory so this check shouldn't cause any issues.

TL;DR:
Opening singleton menu in MHR sometimes crashed, this fixes that.
