### PR TITLE
Lua API Convenience changes

### DIFF
--- a/src/mods/ScriptRunner.cpp
+++ b/src/mods/ScriptRunner.cpp
@@ -55,7 +55,8 @@ ScriptState::ScriptState(const ScriptState::GarbageCollectionData& gc_data) {
     std::scoped_lock _{ m_execution_mutex };
 
     m_lua.registry()["state"] = this;
-    m_lua.open_libraries(sol::lib::base, sol::lib::package, sol::lib::string, sol::lib::math, sol::lib::table, sol::lib::bit32, sol::lib::utf8, sol::lib::os);
+    m_lua.open_libraries(sol::lib::base, sol::lib::package, sol::lib::string, sol::lib::math, sol::lib::table, sol::lib::bit32,
+        sol::lib::utf8, sol::lib::os, sol::lib::coroutine);
 
     // Disable garbage collection. We will manually do it at the end of each frame.
     gc_data_changed(gc_data);


### PR DESCRIPTION
This adds 2 things for convenience with lua scripts:

- Include the coroutine library, I really don't see a reason not to include it, it can make some things really convenient, though it's a bit weird to use.

- Indexing methods for REManagedObject This allows writing lua a bit more like you're using the REManagedObject directly in the script. Colon syntax even works correctly !

Examples
```lua

-- method call
obj:call("handleThing", true, 1)
-- can be written as
obj:handleThing(true, 1)

-- field call
local a = obj:get_field("val1")
-- can be written as
local a = obj.val1

-- field assignement
obj:set_field("val1", 1)
-- can be written as
obj.val1 = 1

```
