### PR TITLE
Universal indexers

### DIFF
--- a/src/mods/bindings/Sdk.cpp
+++ b/src/mods/bindings/Sdk.cpp
@@ -1537,7 +1537,15 @@ void bindings::open_sdk(ScriptState* s) {
         "get_element", &sdk::SystemArray::get_element,
         "get_elements", &sdk::SystemArray::get_elements,
         sol::meta_function::index, api::re_managed_object::index,
-        sol::meta_function::new_index, api::re_managed_object::new_index,
+        sol::meta_function::new_index, [](sol::this_state s, sdk::SystemArray* arr, sol::variadic_args args) {
+            auto index = args[0];
+            auto value = args[1];
+            if (index.is<int32_t>() && value.is<REManagedObject*>()) {
+                return arr->set_element(index, value);
+            }
+            return api::re_managed_object::new_index(s, sol::make_object(s.L, arr), args);
+        },
+
         sol::base_classes, sol::bases<::REManagedObject>()
     );
 

--- a/src/mods/bindings/Sdk.cpp
+++ b/src/mods/bindings/Sdk.cpp
@@ -1536,7 +1536,13 @@ void bindings::open_sdk(ScriptState* s) {
         "get_size", &sdk::SystemArray::size,
         "get_element", &sdk::SystemArray::get_element,
         "get_elements", &sdk::SystemArray::get_elements,
-        sol::meta_function::index, api::re_managed_object::index,
+        sol::meta_function::index, [](sol::this_state s, sdk::SystemArray* arr, sol::variadic_args args) {
+            auto index = args[0];
+            if (index.is<int32_t>()) {
+                return sol::make_object(s.L, arr->get_element(index));
+            }
+            return api::re_managed_object::index(s, sol::make_object(s.L, arr), args);
+        },
         sol::meta_function::new_index, [](sol::this_state s, sdk::SystemArray* arr, sol::variadic_args args) {
             auto index = args[0];
             auto value = args[1];

--- a/src/mods/bindings/Sdk.cpp
+++ b/src/mods/bindings/Sdk.cpp
@@ -1098,7 +1098,7 @@ sol::object index(sol::this_state s, sol::object lua_obj, sol::variadic_args arg
 void new_index(sol::this_state s, sol::object lua_obj, sol::variadic_args args) {
     auto obj = lua_obj.as<REManagedObject*>();
     if (obj == nullptr) {
-        throw sol::error("Attempted to index invalid REManagedObject");
+        throw sol::error("Attempted to new_index invalid REManagedObject");
     }
 
     auto index = args[0];
@@ -1116,8 +1116,9 @@ void new_index(sol::this_state s, sol::object lua_obj, sol::variadic_args args) 
     }
     if (type_def->get_method("set_Item") != nullptr) {
         ::api::sdk::call_native_func(lua_obj, type_def, "set_Item", args);
+        return;
     }
-    throw sol::error("Attempted to index invalid REManagedObject field: " + name);
+    throw sol::error("Attempted to new_index invalid REManagedObject field: " + name);
 }
 
 bool is_valid_offset(::REManagedObject* obj, int32_t offset) {
@@ -1531,12 +1532,8 @@ void bindings::open_sdk(ScriptState* s) {
         "get_size", &sdk::SystemArray::size,
         "get_element", &sdk::SystemArray::get_element,
         "get_elements", &sdk::SystemArray::get_elements,
-        sol::meta_function::index, [](sdk::SystemArray* arr, int32_t index) {
-            return arr->get_element(index);
-        },
-        sol::meta_function::new_index, [](sdk::SystemArray* arr, int32_t index, ::REManagedObject* value) {
-            arr->set_element(index, value);
-        },
+        sol::meta_function::index, api::re_managed_object::index,
+        sol::meta_function::new_index, api::re_managed_object::new_index,
         sol::base_classes, sol::bases<::REManagedObject>()
     );
 


### PR DESCRIPTION
Redirects lua index calls to set_Item or get_Item calls if they exist. 

This allows natural indexing of all collection types that support indexing, like dictionaries, lists, and notably arrays.

Since the new indexing method just falls back to a lua method call, it will now transform value types correctly, which means you can directly get and set numbers from number arrays. This is unfortunately a breaking change, as array indexing right now can only interact with managed objects of numbers.