### PR TITLE
Add namespace hierarchy to json dump

### DIFF
--- a/shared/sdk/RETypeDefinition.cpp
+++ b/shared/sdk/RETypeDefinition.cpp
@@ -273,6 +273,43 @@ std::string RETypeDefinition::get_full_name() const {
 #endif
 }
 
+std::vector<std::string> RETypeDefinition::get_name_hierarchy() const {
+    std::deque<std::string> names{};
+    std::string full_name{};
+
+    if (this->declaring_typeid > 0 && this->declaring_typeid != this->get_index()) {
+        std::unordered_set<const sdk::RETypeDefinition*> seen_classes{};
+
+        for (auto owner = this; owner != nullptr; owner = owner->get_declaring_type()) {
+            if (seen_classes.count(owner) > 0) {
+                break;
+            }
+
+            names.push_front(owner->get_name());
+
+            if (owner->get_declaring_type() == nullptr && !std::string{owner->get_namespace()}.empty()) {
+                names.push_front(owner->get_namespace());
+            }
+
+            // uh.
+            if (owner->get_declaring_type() == this) {
+                break;
+            }
+
+            seen_classes.insert(owner);
+        }
+    } else {
+        // namespace
+        if (!std::string{this->get_namespace()}.empty()) {
+            names.push_front(this->get_namespace());
+        }
+
+        // actual class name
+        names.push_back(this->get_name());
+    }
+    return std::vector<std::string>(names.begin(), names.end());
+}
+
 sdk::RETypeDefinition* RETypeDefinition::get_declaring_type() const {
     auto tdb = RETypeDB::get();
 

--- a/shared/sdk/RETypeDefinition.hpp
+++ b/shared/sdk/RETypeDefinition.hpp
@@ -312,6 +312,7 @@ struct RETypeDefinition : public sdk::RETypeDefinition_ {
     const char* get_name() const;
 
     std::string get_full_name() const;
+    std::vector<std::string> get_name_hierarchy() const;
 
     sdk::RETypeDefinition* get_declaring_type() const;
     sdk::RETypeDefinition* get_parent_type() const;

--- a/src/mods/tools/ObjectExplorer.cpp
+++ b/src/mods/tools/ObjectExplorer.cpp
@@ -862,6 +862,7 @@ void ObjectExplorer::generate_sdk() {
             }
         }
 
+        type_entry["name_hierarchy"] = t.get_name_hierarchy();
         type_entry["is_generic_type"] = t.is_generic_type();
         type_entry["is_generic_type_definition"] = t.is_generic_type_definition();
 


### PR DESCRIPTION
Having an actual clean list of the elements of the type makes the dump a lot easier to process automatically. 
This is a naive copy-paste way of doing it, so I'm open for improvements on this one