### PR TITLE
Fix duplicate types in the object explorer

### DIFF
--- a/src/mods/tools/ObjectExplorer.cpp
+++ b/src/mods/tools/ObjectExplorer.cpp
@@ -337,6 +337,7 @@ void ObjectExplorer::on_draw_dev_ui() {
 
     if (m_do_init) {
         init();
+        m_do_init = false;
     }
 
     if (!m_do_init && !ImGui::CollapsingHeader(get_name().data())) {


### PR DESCRIPTION
This is a regression introduced in 7145dbda6cb7cb5b8dd12d9dee14f51850a76ec6.

It used to look like
![image](https://user-images.githubusercontent.com/13600250/185784916-2652b8a7-d1e6-4ebe-8a40-3cbc35ee9898.png)