### PR TITLE
Optimize `game_namespace` string concatenation and avoid copies

### DIFF
--- a/shared/sdk/RETypes.cpp
+++ b/shared/sdk/RETypes.cpp
@@ -13,17 +13,33 @@ std::unique_ptr<RETypes>& get_types() {
 }
 }
 
-std::string game_namespace(std::string_view base_name)
+std::string& game_namespace(std::string_view base_name)
 {
+    using namespace std::string_view_literals;
+
+    static constexpr std::string_view prefix{
 #ifdef MHRISE
-    return std::string{ "snow." } + base_name.data();
+    "snow."sv
 #elif defined(RE8) || defined(RE7) || defined(DMC5)
-    return std::string{ "app." } + base_name.data();
+    "app."sv
 #elif RE3
-    return std::string{ "offline." } + base_name.data();
+    "offline."sv
 #else
-    return std::string{ "app.ropeway." } + base_name.data();
+    "app.ropeway."sv
 #endif
+    };
+
+    static thread_local std::string buffer = [&]
+    {
+        std::string result{prefix};
+        result.reserve(128);
+        return result;
+    }();
+
+    buffer.resize(prefix.size());
+    buffer.insert(prefix.size(), base_name.data());
+
+    return buffer;
 }
 
 RETypes::RETypes() {

--- a/shared/sdk/RETypes.hpp
+++ b/shared/sdk/RETypes.hpp
@@ -7,7 +7,7 @@
 
 #include "ReClass.hpp"
 
-std::string game_namespace(std::string_view base_name);
+std::string& game_namespace(std::string_view base_name);
 
 class REType;
 


### PR DESCRIPTION
Untested, similarly to #505. I just found another function that's frequently called and that's doing more work than it should. Might not matter for performance at all, or might reduce CPU usage slightly due to the avoidance of copies and dynamic string allocations.

I am not sure if `thread_local` is required, but I added it just to be safe. I also think it should be safe to change the return type to `std::string&` as in the PR, but that should be double-checked as well.
