### PR TITLE
DInputHook: Initialize g_dinput_hook before installing hook.

### DIFF
--- a/src/DInputHook.cpp
+++ b/src/DInputHook.cpp
@@ -15,11 +15,12 @@ DInputHook::DInputHook(HWND wnd)
     m_do_once{ true }
 {
     if (g_dinput_hook == nullptr) {
+        g_dinput_hook = this;
         if (hook()) {
             spdlog::info("DInputHook hooked successfully.");
-            g_dinput_hook = this;
         }
         else {
+            g_dinput_hook = nullptr;
             spdlog::info("DInputHook failed to hook.");
         }
     }


### PR DESCRIPTION
Fixes frequent crashes during dinput hooking on Proton (on Windows too but there it is probably a rare occasion).

g_dinput_hook is used in the hook function. DInputHook::DInputHook() sets g_dinput_hook only after hook() finishes. The hook gets active in m_get_device_state_hook->create(), inside MH_EnableHook(). MH_EnableHook() suspends game threads, activates hook and resumes the threads. Once thread calling GetDeviceState() is resumed it may start calling the hook function. The patch fixes the crash which happens frequently under Steam Proton due to that. The crash happens much less often on Windows probably because Proton's ResumeThread() is slower to execute on the calling thread and faster to wake the thread being resumed compared to Windows.