### PR TITLE
Add pattern for MHR GP version to pathdumper

### DIFF
--- a/reversing/scripts/pathdumper/pathdumper.py
+++ b/reversing/scripts/pathdumper/pathdumper.py
@@ -32,6 +32,7 @@ const m = Process.enumerateModules()[0];
 const patterns = ['40 55 41 54 41 55 41 57 48 8D AC 24 ?? ?? ?? ?? B8', // RE2/RE3/DMC5/GnG no RT
                   '40 55 53 41 55 48 8d AC 24 ?? ?? ?? ?? B8 50 18 00 00', // RE7 no RT
                   '40 55 53 41 56 48 8d ac 24 ?? ?? ?? ?? b8 40 10 00 00', // RE7/RE2/RE3 RT
+                  '40 55 53 41 56 48 8d ac 24 ?? ?? ?? ?? b8 50 10 00 00', // MHRise Gamepass
 ];
 
 for (var i = 0; i < patterns.length; i++) {


### PR DESCRIPTION
I added a pattern for creating filelist with pathdumper for MH Rise Gamepass version

Example output:

`natives/msg/stage/v01/textures/v01_ita15_albd.tex.143221028
natives/msg/streaming/stage/v01/textures/v01_ita15_albd.tex.143221028
natives/msg/stage/v01/textures/v01_hone04_albd.tex.143221028
natives/msg/streaming/stage/v01/textures/v01_hone04_albd.tex.143221028
natives/msg/stage/v01/textures/v01_ita15_nrmr.tex.143221028
natives/msg/streaming/stage/v01/textures/v01_ita15_nrmr.tex.143221028`