### PR TITLE
Throttle D3D12 wait loop.

### DIFF
--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -216,10 +216,12 @@ REFramework::REFramework(HMODULE reframework_module)
     std::chrono::steady_clock::time_point next_log = now;
 
     while (GetModuleHandleA("d3d12.dll") == nullptr) {
+        now = std::chrono::steady_clock::now();
         if (now >= next_log) {
             spdlog::info("[REFramework] Waiting for D3D12...");
             next_log = now + 1s;
         }
+        Sleep(50);
     }
 
     while (LoadLibraryA("d3d12.dll") == nullptr) {


### PR DESCRIPTION
And fix logging in it.

REFramework currently waits for d3d12.dll load by calling GetModuleHandleA() in a tight loop. That makes RE4 Demo load time with REFramework go up to ~15min in Wine / Proton. That is much less of an issue on Windows because the difference of loader locking model between modern Windows and Wine: on Wine, the loader lock is taken and spending most of the time in GetModuleHandleA() effectively stops loading the other DLLs for the most of the time. That is non-trivial to fix at once in Wine. Also, while on modern Windows this is much less of an issue (as loader lock is not taken for GetModuleHandle), it still generates a constant load in parallel to game's load and throttling this loop might improve loading time a bit on Windows as well.