### PR TITLE
Fixes for random lockups on start with Proton

### DIFF
--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -280,7 +280,7 @@ REFramework::REFramework(HMODULE reframework_module)
 
     if (lock_loader != nullptr && unlock_loader != nullptr)
         lock_loader(0, NULL, &loader_magic);
-    utility::ThreadSuspender ___{};
+    utility::ThreadSuspender suspender{};
     if (lock_loader != nullptr && unlock_loader != nullptr)
         unlock_loader(0, loader_magic);
 
@@ -295,6 +295,7 @@ REFramework::REFramework(HMODULE reframework_module)
     // Fixes new code added in RE4 only.
     IntegrityCheckBypass::immediate_patch_re4();
 #endif
+    suspender.resume();
 #endif
 
     // Hooking D3D12 initially because we need to retrieve the command queue before the first frame then switch to D3D11 if it failed later


### PR DESCRIPTION
RE4 now randomly lockups on start under Wine / Proton with REFramework.

The first reason for that (fixed by the first patch) is that when threads are suspended that may happen while they are holding loader lock (due to, e. g., loading or process / thread attaching dlls, i. e., being inside DllMain). That doesn't immediately lock up on Windows as on modern windows GetModuleHandle() and some other queries do not take loader lock but still do so on Wine. Some other cases also take a loader lock though and block while suspended threads hold it, like LoadLibrary, or any newly created thread will block on loader lock before calling DllMain. So it is maybe best to make sure the threads being suspended don't hold loader lock on Windows as well.

The other lockup (fixed by second patch) which is also randomly reproduced is trickier but also related to suspending threads in unfortunate moments (and then creating a new thread locks the creating thread). This is an internal Wine bug which is hard to fix though, but at the same time fix for it in REFramework seems much more straightforward: it is probably no reason to keep the threads suspended until the constructor ends as this suspend doesn't even happen in a generic case (not invoving re4 and re8) and the rest of the constructor works without threads suspension anyway.