### PR TITLE
set unicorn version for rsz dumper

### DIFF
--- a/reversing/rsz/requirements.txt
+++ b/reversing/rsz/requirements.txt
@@ -1,5 +1,5 @@
 fire
 numpy
-unicorn
+unicorn==1.0.3
 capstone
 pefile


### PR DESCRIPTION
There will be some missing field if we use unicorn>=2.0.0 when dumping rsz. So it is better to let it stay at 1.0.3