### PR TITLE
Fixed get_native_singleton retuning nullptr.

### DIFF
--- a/shared/sdk/REGlobals.cpp
+++ b/shared/sdk/REGlobals.cpp
@@ -125,7 +125,7 @@ std::vector<REManagedObject*> REGlobals::get_objects() {
     return out;
 }
 
-void* REGlobals::get_native(std::string_view name) {
+REType* REGlobals::get_native(std::string_view name) {
     std::lock_guard _{ m_map_mutex };
 
     if (m_native_singleton_types.empty()) {

--- a/shared/sdk/REGlobals.hpp
+++ b/shared/sdk/REGlobals.hpp
@@ -20,7 +20,7 @@ public:
 
     std::vector<REManagedObject*> get_objects();
 
-    void* get_native(std::string_view name);
+    REType* get_native(std::string_view name);
     std::vector<::REType*>& get_native_singleton_types();
 
     // Equivalent

--- a/shared/sdk/RETypeDB.hpp
+++ b/shared/sdk/RETypeDB.hpp
@@ -83,6 +83,7 @@ T* create_instance(std::string_view type_name, bool simplify = false);
 #include "REManagedObject.hpp"
 #include "REContext.hpp"
 #include "TDBVer.hpp"
+#include "REGlobals.hpp"
 
 namespace sdk {
 namespace tdb71 {
@@ -1013,15 +1014,21 @@ T* get_static_field(std::string_view type_name, std::string_view name, bool is_v
 }
 
 template <typename T>
-T* get_native_singleton(std::string_view type_name) {
-    auto t = sdk::find_type_definition(type_name);
-
-    if (t == nullptr) {
-        //spdlog::error("Cannot find type {:s}", type_name.data());
+T* get_native_singleton(std::string_view type_name) 
+{
+    auto t = reframework::get_globals()->get_native(type_name);
+    if (t == nullptr) 
+    {
         return nullptr;
     }
 
-    return (T*)t->get_instance();
+    auto instance = utility::re_type::get_singleton_instance(t);
+    if (instance == nullptr) 
+    {
+        return nullptr;
+    }
+
+    return (T*)instance;
 }
 
 template <typename T>


### PR DESCRIPTION
Some native singletons (like via.gui.GUIManager) do not have a RETypeDef, only a REType. get_native_singleton failed for them due to looking for a RETypeDef.