### PR TITLE
Potential native rsz name

### DIFF
--- a/reversing/rsz/non-native-dumper.py
+++ b/reversing/rsz/non-native-dumper.py
@@ -27,6 +27,7 @@ hardcoded_align_sizes = {
     "C16": als(2, 2),
     "S16": als(2, 2),
     "U16": als(2, 2),
+    "F16": als(2, 2),
     
     "S32": als(4, 4),
     "U32": als(4, 4),
@@ -41,18 +42,229 @@ hardcoded_align_sizes = {
     "Resource": als(4, 4),
     "String": als(4, 4),
     "RuntimeType": als(4, 4),
+
+    "Quaternion": als(16, 16),
+    "Guid": als(8, 16),
+    "GameObjectRef": als(8, 16),
+    "Color": als(4, 4),
+    "DateTime": als(8, 8),
+    # Enum could have variable size and alignment, so we fallback to its base type and never use it.
+
+    "Uint2": als(4, 8),
+    "Uint3": als(4, 12),
+    "Uint4": als(4, 16),
+    "Int2": als(4, 8),
+    "Int3": als(4, 12),
+    "Int4": als(4, 16),
+    "Float2": als(4, 8),
+    "Float3": als(4, 12),
+    "Float4": als(4, 16),
+    "Mat4": als(16, 64),
+    "Vec2": als(16, 16),
+    "Vec3": als(16, 16),
+    "Vec4": als(16, 16),
+
+    "AABB": als(16, 32),
+    "Capsule": als(16, 48),
+    "Cone": als(16, 32),
+    "LineSegment": als(16, 32),
+    "OBB": als(16, 80),
+    "Plane": als(16, 16),
+    "Point": als(4, 8),
+    "Range": als(4, 8),
+    "RangeI": als(4, 8),
+    "Size": als(4, 8),
+    "Sphere": als(16, 16),
+    "Triangle": als(16, 48),
+    "Cylinder": als(16, 48),
+    "Area": als(16, 48),
+    "Rect": als(4, 16),
+    "Frustum": als(16, 96),
+    "KeyFrame": als(16, 16),
+
+    "Sfix": als(4, 4),
+    "Sfix2": als(4, 8),
+    "Sfix3": als(4, 12),
+    "Sfix4": als(4, 16),
 }
 
-def generate_native_name(element):
+hardcoded_native_type_to_TypeCode = {
+    'float': 'F32',
+    'int': 'S32',
+    'size_t': 'U32',
+
+    'via.GameObject': 'Object',
+
+    'System.Boolean': 'Bool',
+    'System.Char': 'C8',
+    'System.SByte': 'S8',
+    'System.Byte': 'U8',
+    'System.Int16': 'S16',
+    'System.UInt16': 'U16',
+    'System.Int32': 'S32',
+    'System.UInt32': 'U32',
+    'System.Int64': 'S64',
+    'System.UInt64': 'U64',
+    'System.Single': 'F32',
+    'System.Double': 'F64',
+}
+
+TypeCode = [
+    # "Undefined",
+    "Object",
+    "Action",
+    "Struct",
+    "NativeObject",
+    "Resource",
+    "UserData",
+    "Bool",
+    "C8",
+    "C16",
+    "S8",
+    "U8",
+    "S16",
+    "U16",
+    "S32",
+    "U32",
+    "S64",
+    "U64",
+    "F32",
+    "F64",
+    "String",
+    "MBString",
+    "Enum",
+    "Uint2",
+    "Uint3",
+    "Uint4",
+    "Int2",
+    "Int3",
+    "Int4",
+    "Float2",
+    "Float3",
+    "Float4",
+    "Float3x3",
+    "Float3x4",
+    "Float4x3",
+    "Float4x4",
+    "Half2",
+    "Half4",
+    "Mat3",
+    "Mat4",
+    "Vec2",
+    "Vec3",
+    "Vec4",
+    "VecU4",
+    "Quaternion",
+    "Guid",
+    "Color",
+    "DateTime",
+    "AABB",
+    "Capsule",
+    "TaperedCapsule",
+    "Cone",
+    "Line",
+    "LineSegment",
+    "OBB",
+    "Plane",
+    "PlaneXZ",
+    "Point",
+    "Range",
+    "RangeI",
+    "Ray",
+    "RayY",
+    "Segment",
+    "Size",
+    "Sphere",
+    "Triangle",
+    "Cylinder",
+    "Ellipsoid",
+    "Area",
+    "Torus",
+    "Rect",
+    "Rect3D",
+    "Frustum",
+    "KeyFrame",
+    "Uri",
+    "GameObjectRef",
+    "RuntimeType",
+    "Sfix",
+    "Sfix2",
+    "Sfix3",
+    "Sfix4",
+    "Position",
+    "F16",
+    "Decimal",
+    # "End",
+]
+
+TypeCodeSearch = dict([(k.lower(),v) for k,v in hardcoded_native_type_to_TypeCode.items()] + [(a.lower(), a) for a in TypeCode] + [("via."+a.lower(), a) for a in TypeCode] + [("system."+a.lower(), a) for a in TypeCode])
+# print(TypeCodeSearch)
+
+def generate_native_name(element, use_potential_name, reflection_property, il2cpp_dump={}):
     if element is None:
         os.system("Error")
 
     if element["string"] == True:
+        if use_potential_name:
+            property_type = reflection_property["type"]
+            type_code = TypeCodeSearch.get(property_type.lower(), "Data")
+
+            if type_code == "Data" and property_type.startswith("via."):
+                native_element = il2cpp_dump.get(property_type, None)
+
+                if native_element is None:
+                    if (property_type.endswith("ResourceHandle") or property_type.endswith("ResorceHandle")) and property_type.startswith("via."):
+                        property_type = property_type.replace("ResourceHandle", "ResourceHolder")
+                        property_type = property_type.replace("ResorceHandle", "ResorceHolder") # arrrrrrrrrr
+                        native_element = il2cpp_dump.get(property_type, None)
+                        chain = native_element.get('deserializer_chain', None)
+
+                        if "via.ResourceHolder" in [a['name'] for a in chain]: # ResourcePath
+                            return "Resource"
+            else:
+                if type_code in ["C16","C8","String"]:
+                    return "String"
+                
+            return type_code
         return "String"
     elif element["list"] == True:
-        return generate_native_name(element["element"])
-    
+        return generate_native_name(element["element"], use_potential_name, reflection_property, il2cpp_dump)
+    elif use_potential_name and reflection_property is not None:
+        property_type = reflection_property["type"]
+        type_code = TypeCodeSearch.get(property_type.lower(), "Data")
+
+        if type_code == "Data" and property_type.startswith("via."):
+            native_element = il2cpp_dump.get(property_type, None)
+
+            if native_element is None:
+                return type_code
+
+            parent = native_element.get('parent', None)
+            if parent is not None:
+                parent_type_code = TypeCodeSearch.get(parent.lower(), "Data")
+                if parent_type_code != 'Data':
+                    return parent_type_code
+                
+            chain = native_element.get('deserializer_chain', None)
+            if chain is not None:
+                for chain_i in reversed(chain):
+                    chain_type_code = TypeCodeSearch.get(chain_i['name'].lower(), "Data")
+                    if chain_type_code != 'Data':
+                        return chain_type_code
+        
+        return type_code
     return "Data"
+
+def enum_fallback(reflection_property, il2cpp_dump={}):
+    native_element = il2cpp_dump.get(reflection_property["type"], None)
+    # Enum type should have and only have one "RSZ" field. These check are just for safety. 
+    if native_element is None:
+        return "Enum"
+    if "RSZ" not in native_element:
+        return "Enum"
+    if len(native_element["RSZ"]) != 1:
+        return "Enum"
+    return native_element["RSZ"][0]["code"]
 
 def generate_field_entries(il2cpp_dump, natives, key, il2cpp_entry, use_typedefs, prefix = "", i=0, struct_i=0):
     e = il2cpp_entry
@@ -85,14 +297,64 @@ def generate_field_entries(il2cpp_dump, natives, key, il2cpp_entry, use_typedefs
             struct_str = struct_str + "// " + chain["name"] + " BEGIN\n"
             
             layout = chain["layout"]
-            for field in layout:
-                native_type_name = generate_native_name(field)
+
+            # Get reflection_properties for guessing native type name.
+            reflection_properties = il2cpp_dump[chain["name"]].get("reflection_properties", None)
+            append_potential_name = False
+
+            # If len not match, we give-up
+            if len(layout) == len(reflection_properties):
+                append_potential_name = True
+
+                # sort reflection_properties by its native order
+                order_rp = [(int(v["order"]), (k,v)) for k, v in reflection_properties.items()]
+                reflection_properties = dict([v for _, v in sorted(order_rp)])
+
+                # check align and size to increase accuracy
+                for (property_name, property_value), field in zip(reflection_properties.items(), layout):
+                    property_type_code = generate_native_name(field, True, property_value, il2cpp_dump)
+
+                    if property_type_code == "Enum":
+                        property_type_code = enum_fallback(property_value, il2cpp_dump)
+
+                    reflection_properties[property_name]["TypeCode"] = property_type_code
+
+                    if property_type_code == "Data":
+                        continue
+                    if "element" in field and "list" in field and field["list"] == True:
+                        field_align = field["element"]["align"]
+                        field_size = field["element"]["size"]
+                    else:
+                        field_align = field["align"]
+                        field_size = field["size"]
+
+                    property_align = hardcoded_align_sizes[property_type_code]["align"]
+                    property_size = hardcoded_align_sizes[property_type_code]["size"]
+
+                    if property_align != field_align or property_size != field_size:
+                        append_potential_name = False
+
+            if append_potential_name:
+                rp_names = list(reflection_properties.keys())
+                rp_values = list(reflection_properties.values())
+
+            for rp_idx, field in enumerate(layout):
                 native_field_name = "v" + str(i)
+                if not append_potential_name:
+                    native_type_name = generate_native_name(field, False, None)
+                    native_org_type_name = ""
+                else:
+                    native_type_name = rp_values[rp_idx]["TypeCode"]
+                    native_field_name += "_" + rp_names[rp_idx]
+                    # native_field_name = rp_names[rp_idx] # without start with v_
+                    native_org_type_name = rp_values[rp_idx]['type']
+                    if native_type_name != "Data" and not native_org_type_name.startswith("via"):
+                        native_org_type_name = "" # those would be sth like "bool" "s32"
 
                 new_entry = {
                     "type": native_type_name,
                     "name": native_field_name,
-                    "original_type": "",
+                    "original_type": native_org_type_name,
                     "align": field["align"],
                     "size": field["size"],
                     "native": True

--- a/src/mods/tools/ObjectExplorer.cpp
+++ b/src/mods/tools/ObjectExplorer.cpp
@@ -1920,7 +1920,7 @@ void ObjectExplorer::generate_sdk() {
         // Generate Properties
         if (fields->variables != nullptr && fields->variables != nullptr && fields->variables->data != nullptr) {
             auto descriptors = fields->variables->data->descriptors;
-
+            auto reflection_property_index = 0;
             for (auto i = descriptors; i != descriptors + fields->variables->num; ++i) {
                 auto variable = *i;
 
@@ -1967,6 +1967,7 @@ void ObjectExplorer::generate_sdk() {
                 prop_entry = {
                     {"getter", (std::stringstream{} << "0x" << std::hex << get_original_va(variable->function)).str()},
                     {"type", field_t_name},
+                    {"order", reflection_property_index++},
                 };
 #endif
             


### PR DESCRIPTION
Add potential native rsz name / type / original type name

Note that I add a field to `reflection_properties` in il2cpp.json dump to store its native order.
An alternative is use `ordered_json`, but it impacts performance a lot (1 min dump -> 7 min dump) so i decided just add a key into it.

By default the name of that native type is append after `v{number}`, like `v0_Enabled`