### PR TITLE
RE2/RE3 fixes, Joystick Smoothing, Smooth Locomotion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/sdk/generated
 cmake-build*
 .idea/
 build_vs2019_devmode_DMC5.bat
+CMakeLists.txt

--- a/src/mods/FirstPerson.hpp
+++ b/src/mods/FirstPerson.hpp
@@ -27,6 +27,7 @@ public:
 
     // (sibest) Smooth Locomotion
     bool smooth_move(Vector3f direction, bool running);
+    bool hook_rotation(Vector3f direction);
 
     std::string_view get_name() const override { return "FirstPerson"; };
     std::optional<std::string> on_initialize() override;
@@ -71,6 +72,7 @@ private:
     void reset();
     void set_vignette(via::render::ToneMapping::Vignetting value);
     bool update_pointers();
+    void update_camera_status();
     bool update_pointers_from_camera_system(RopewayCameraSystem* camera_system);
     void update_player_vr(RETransform* transform, bool first = false);
     void update_player_arm_ik(RETransform* transform);
@@ -78,8 +80,12 @@ private:
     void update_player_body_ik(RETransform* transform, bool restore = false, bool first = false);
     void update_player_body_rotation(RETransform* transform);
     void update_player_roomscale(RETransform* transform);
-    void update_player_smooth_locomotion(RETransform* transform);
+    void update_player_smooth_locomotion_vr(RETransform* transform);
+    void update_player_rotation_vr();
+    void update_camera_transform_vr(RETransform* transform);
+    void update_camera_transform_std(RETransform* transform);
     void update_camera_transform(RETransform* transform);
+
     void update_sweet_light_context(RopewaySweetLightManagerContext* ctx);
     void update_player_bones(RETransform* transform);
     void update_fov(RopewayPlayerCameraController* controller);
@@ -131,8 +137,9 @@ private:
     float m_interp_camera_speed{ 100.0f };
     float m_interp_bone_scale{ 1.0f };
     float m_vr_scale{ 1.0f };
-    std::chrono::steady_clock::time_point m_last_roomscale_failure{ std::chrono::steady_clock::now() };
+    std::chrono::steady_clock::time_point m_last_roomscale_failure{std::chrono::steady_clock::now()};
     std::chrono::steady_clock::time_point m_last_locomotion_time{std::chrono::steady_clock::now()};
+    std::chrono::steady_clock::time_point m_last_rotation_time{std::chrono::steady_clock::now()};
 
     Vector4f m_scale_debug{ 1.0f, 1.0f, 1.0f, 1.0f };
     Vector4f m_scale_debug2{ 1.0f, 1.0f, 1.0f, 1.0f };
@@ -143,7 +150,9 @@ private:
     Vector3f m_right_hand_rotation_offset{ 0.2f, -2.5f, -1.7f };
 
     Vector3f m_last_controller_euler[2]{};
+    Vector3f m_looking_at{0.f, 0.f, 0.f};
 
+    Vector3f m_rotating{0.f, 0.f, 0.f};
     Vector3f m_steering{0.f, 0.f, 0.f};
     Vector3f m_velocity{0.f, 0.f, 0.f};
     float m_max_speed{0.f};
@@ -180,7 +189,7 @@ private:
     const ModToggle::Ptr m_smooth_locomotion{ModToggle::create(generate_name("SmoothLocomotion"), true)};
     const ModToggle::Ptr m_smooth_xz_movement{ ModToggle::create(generate_name("SmoothXZMovementVR"), true) };
     const ModToggle::Ptr m_smooth_y_movement{ ModToggle::create(generate_name("SmoothYMovementVR"), true) };
-    const ModToggle::Ptr m_roomscale{ ModToggle::create(generate_name("RoomScale"), false) };
+    const ModToggle::Ptr m_roomscale{ ModToggle::create(generate_name("RoomScale"), true) };
     const ModToggle::Ptr m_disable_vignette{ ModToggle::create(generate_name("DisableVignette"), true) };
     const ModToggle::Ptr m_hide_mesh{ ModToggle::create(generate_name("HideJointMesh"), true) };
     const ModToggle::Ptr m_hide_upper_body{ModToggle::create(generate_name("HideUpperBodyMesh"), false)};

--- a/src/mods/Hooks.cpp
+++ b/src/mods/Hooks.cpp
@@ -128,9 +128,11 @@ void Hooks::RenderLayerHook<sdk::renderer::layer::##x2##>::##x3##(sdk::renderer:
     } \
     bool any_false = false; \
     const auto& mods = g_framework->get_mods()->get_mods(); \
+    std::vector<Mod*> skip; \
     for (auto& mod : mods) { \
         const auto result = mod->on_pre_##x##_layer_##x3##(layer, render_ctx); \
         if (!result) { \
+            skip.push_back(mod.get()); \
             any_false = true; \
         } \
     } \
@@ -139,6 +141,7 @@ void Hooks::RenderLayerHook<sdk::renderer::layer::##x2##>::##x3##(sdk::renderer:
         original_func(layer, render_ctx); \
     } \
     for (auto& mod : mods) { \
+        if (std::find(skip.begin(), skip.end(), mod.get()) == skip.end()) \
         mod->on_##x##_layer_##x3##(layer, render_ctx); \
     }\
 }

--- a/src/mods/VR.hpp
+++ b/src/mods/VR.hpp
@@ -184,7 +184,7 @@ public:
     }
 
     void apply_hmd_transform(glm::quat& rotation, Vector4f& position);
-    void apply_hmd_transform(::REJoint* camera_joint, bool only_rotation = false);
+    void apply_hmd_transform(::REJoint* camera_joint);
     
     bool is_hand_behind_head(VRRuntime::Hand hand, float sensitivity = 0.2f) const;
     bool is_action_active(vr::VRActionHandle_t action, vr::VRInputValueHandle_t source = vr::k_ulInvalidInputValueHandle) const;
@@ -360,7 +360,7 @@ private:
     void update_hmd_state();
     void update_action_states();
     void update_camera(); // if not in firstperson mode
-    void update_camera_origin(bool only_rotation = false); // every frame
+    void update_camera_origin(); // every frame
     void update_audio_camera();
     void update_render_matrix();
     void restore_audio_camera(); // after wwise listener update
@@ -437,6 +437,7 @@ private:
 
     bool m_was_firstperson_toggle_down{false};
     bool m_was_flashlight_toggle_down{false};
+    volatile int m_scene_layer_locked{0};
     
     
     std::unordered_map<std::string, std::reference_wrapper<vr::VRActionHandle_t>> m_action_handles {

--- a/src/mods/vr/CameraDuplicator.cpp
+++ b/src/mods/vr/CameraDuplicator.cpp
@@ -153,14 +153,15 @@ void CameraDuplicator::find_new_camera() {
                 spdlog::info("Found new camera: {:x}", (uintptr_t)m_new_camera);
 
                 // Parent this camera's transform to the old one
+                // (sibest): in RE2/RE3 this causes the right eye to shake. In other games this is useless.
+                /*
                 const auto new_transform = gameobject->transform;
                 const auto old_transform = utility::re_component::get_game_object((REComponent*)m_old_camera)->transform;
 
                 if (new_transform != nullptr && old_transform != nullptr) {
                     sdk::call_object_func_easy<void*>(new_transform, "setParent(via.Transform, System.Boolean)", old_transform, false);
                     spdlog::info("Parented new camera to old camera");
-                }
-
+                }*/
                 break;
             }
         }
@@ -208,6 +209,7 @@ void CameraDuplicator::copy_camera_properties() {
     // Do not allow the camera components to update. We will do the update ourselves via the copying of properties
     // FIX (sibest): The new camera object must update, otherewise there will be glitches like movement stuck in RE2/RE3 and RE8
     // For some reason the RE engine randomly uses the new camera as main camera sometimes.
+    // Moreover, in RE2/RE3 if new_camera->shouldUpdate is false enemies move at reduced fps.
     // new_camera_gameobject->shouldUpdate = false;
 
     static auto via_camera = sdk::find_type_definition("via.Camera");

--- a/src/mods/vr/CameraDuplicator.cpp
+++ b/src/mods/vr/CameraDuplicator.cpp
@@ -286,7 +286,9 @@ void CameraDuplicator::copy_camera_properties() {
 
             // Add property jobs, the copying will be spread out over multiple frames as it is a lot of work
             // Call the various getters and setters
-            /* for (const auto& [name, methods] : m_getter_setters[t1]) {
+            if (!descriptor.immediate)
+            for (const auto& [name, methods] : m_getter_setters[t1]) {
+
                 if (methods.getter == nullptr || methods.setter == nullptr) {
                     continue;
                 }
@@ -315,11 +317,12 @@ void CameraDuplicator::copy_camera_properties() {
                         }
                     }
                 });
-            }*/
+            }
         }
 
         // Call the various getters and setters
         // FIX (sibest): Camera properties must be set every frame otherwise the new camera flickers
+        if (descriptor.immediate)
         for (const auto& [name, methods] : m_getter_setters[t1]) {
             if (methods.getter != nullptr && methods.setter != nullptr) {
                 const auto result = methods.getter->invoke(old_component, {});

--- a/src/mods/vr/CameraDuplicator.hpp
+++ b/src/mods/vr/CameraDuplicator.hpp
@@ -35,19 +35,24 @@ private:
         std::string name{};
         std::unordered_set<size_t> ignored_properties{};
         bool allowed{true}; // used for debug imgui checkbox
+        bool immediate{false}; // used to set which property must be set every frame
     };
 
     // Components that we want to copy from the old camera to the new camera
     std::vector<WantedComponent> m_wanted_components {
-        WantedComponent{ "via.render.ToneMapping", { "set_InjectingGameObject"_fnv } },
-        WantedComponent{ "via.render.LDRPostProcess", {} },
-        WantedComponent{ "via.render.SoftBloom", {} },
+        
+        /* the first three components have manual properties setting every frame, so the setters/getters must be immediate */
+        WantedComponent{ "via.render.ToneMapping", { "set_InjectingGameObject"_fnv }, true, true }, 
+        WantedComponent{ "via.render.LDRPostProcess", {}, true, true },
+        WantedComponent{ "via.render.SoftBloom", {}, true, true },
+
+        WantedComponent{ "via.render.Outline", {}},
+        WantedComponent{ "via.render.Retrofilm", {}},
         WantedComponent{ "via.render.SSRControl", {} },
         WantedComponent{ "via.render.SSAOControl", {} },
         WantedComponent{ "via.render.SSSSSControl", {} },
         WantedComponent{ "via.render.DepthOfField", {} },
         WantedComponent{ "via.render.LightShaftFilterControl", {} },
-        WantedComponent{ "via.render.FakeLensFlare", {} },
         WantedComponent{ "via.render.MotionBlur", {} },
         WantedComponent{ "via.render.FFTBloom", {} },
         WantedComponent{ "via.render.Echo", {} },
@@ -59,6 +64,13 @@ private:
         WantedComponent{ "via.render.VolumetricFogControl", { } },
         WantedComponent{ "via.render.GodRay", { } },
         WantedComponent{ "via.render.GeometryAOControl", { } },
+
+        // arent these needed?
+        //WantedComponent{ "via.render.SubsurfaceSettings", { } },
+        //WantedComponent{ "via.render.CapturePlane", {}},
+        //WantedComponent{ "via.render.CaptureToTexture", {}},
+        //WantedComponent{ "via.render.ExperimentalRayTrace", {}},
+
         WantedComponent{ "via.render.MotionBlur", { } },
         WantedComponent{ "via.render.FakeLensflare", { } },
         //WantedComponent{ "via.render.CustomFilter", { } },


### PR DESCRIPTION
- Fixed the new rendering method to work with RE2/RE3. Probably fixes the RE8 inventory stuck (to-be-tested)
- Added an option to smooth the joystick movement and prevent shaking
- Added an option to enable Smooth Locomotion in VR (RE2/RE3)
- Added an option to hide the head and neck (RE2/RE3)