### PR TITLE
Prefer `CMAKE_CURRENT_SOURCE_DIR` over `CMAKE_SOURCE_DIR` for the project's source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,7 @@ if(REF_BUILD_FRAMEWORK AND CMAKE_SIZEOF_VOID_P EQUAL 8) # build-framework
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${imgui_SOURCES})
 
 	target_compile_definitions(imgui PUBLIC
-		"IMGUI_USER_CONFIG=\"${CMAKE_SOURCE_DIR}/src/re2-imgui/re2_imconfig.hpp\""
+		"IMGUI_USER_CONFIG=\"${CMAKE_CURRENT_SOURCE_DIR}/src/re2-imgui/re2_imconfig.hpp\""
 	)
 
 	target_include_directories(imgui PUBLIC
@@ -308,7 +308,7 @@ if(REF_BUILD_FRAMEWORK AND CMAKE_SIZEOF_VOID_P EQUAL 8) # build-framework
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${imguizmo_SOURCES})
 
 	target_compile_definitions(imguizmo PUBLIC
-		"IMGUI_USER_CONFIG=\"${CMAKE_SOURCE_DIR}/src/re2-imgui/re2_imconfig.hpp\""
+		"IMGUI_USER_CONFIG=\"${CMAKE_CURRENT_SOURCE_DIR}/src/re2-imgui/re2_imconfig.hpp\""
 	)
 
 	target_include_directories(imguizmo PUBLIC
@@ -372,7 +372,7 @@ if(REF_BUILD_FRAMEWORK AND CMAKE_SIZEOF_VOID_P EQUAL 8) # build-framework
 	)
 
 	target_link_libraries(openvr INTERFACE
-		"${CMAKE_SOURCE_DIR}/dependencies/openvr/lib/win64/openvr_api.lib"
+		"${CMAKE_CURRENT_SOURCE_DIR}/dependencies/openvr/lib/win64/openvr_api.lib"
 	)
 
 	file(COPY dependencies/openvr/lib/win64/openvr_api.lib DESTINATION ${CMAKE_BINARY_DIR}/lib)

--- a/cmake.toml
+++ b/cmake.toml
@@ -114,7 +114,7 @@ type = "static"
 sources = ["dependencies/imgui/*.cpp"]
 include-directories = ["dependencies/imgui", "src/re2-imgui"]
 compile-definitions = [
-    "IMGUI_USER_CONFIG=\"${CMAKE_SOURCE_DIR}/src/re2-imgui/re2_imconfig.hpp\"",
+    "IMGUI_USER_CONFIG=\"${CMAKE_CURRENT_SOURCE_DIR}/src/re2-imgui/re2_imconfig.hpp\"",
 ]
 condition = "build-framework"
 
@@ -123,7 +123,7 @@ type = "static"
 sources = ["dependencies/imguizmo/*.cpp"]
 include-directories = ["dependencies/imgui", "dependencies/imguizmo", "src/re2-imgui"]
 compile-definitions = [
-    "IMGUI_USER_CONFIG=\"${CMAKE_SOURCE_DIR}/src/re2-imgui/re2_imconfig.hpp\"",
+    "IMGUI_USER_CONFIG=\"${CMAKE_CURRENT_SOURCE_DIR}/src/re2-imgui/re2_imconfig.hpp\"",
 ]
 condition = "build-framework"
 
@@ -138,7 +138,7 @@ link-libraries = ["imgui"]
 type = "interface"
 include-directories = ["dependencies/openvr/headers"]
 link-libraries = [
-    "${CMAKE_SOURCE_DIR}/dependencies/openvr/lib/win64/openvr_api.lib",
+    "${CMAKE_CURRENT_SOURCE_DIR}/dependencies/openvr/lib/win64/openvr_api.lib",
 ]
 cmake-after = """
 file(COPY dependencies/openvr/lib/win64/openvr_api.lib DESTINATION ${CMAKE_BINARY_DIR}/lib)

--- a/examples/weapon_stay_big_plugin/weapon_stay_big.cpp
+++ b/examples/weapon_stay_big_plugin/weapon_stay_big.cpp
@@ -1,14 +1,14 @@
 #include <Windows.h>
 #include <reframework/API.hpp>
 
-int pre_start(int argc, void** argv, REFrameworkTypeDefinitionHandle* arg_tys) {
+int pre_start(int argc, void** argv, REFrameworkTypeDefinitionHandle* arg_tys, unsigned long long ret_addr) {
     auto obj = (reframework::API::ManagedObject*)argv[1];
     *obj->get_field<float>("_bodyConstScale") = 1.0f;
 
     return REFRAMEWORK_HOOK_CALL_ORIGINAL;
 }
 
-void post_start(void** ret_val, REFrameworkTypeDefinitionHandle ret_ty) {
+void post_start(void** ret_val, REFrameworkTypeDefinitionHandle ret_ty, unsigned long long ret_addr) {
 }
 
 extern "C" __declspec(dllexport) void reframework_plugin_required_version(REFrameworkPluginVersion* version) {


### PR DESCRIPTION
1. Switch from `CMAKE_SOURCE_DIR` to `CMAKE_CURRENT_SOURCE_DIR` when specifying the imgui config path and openvr library. This makes it so others can build REF as an embedded dependency via cmake's `add_subdirectory`
2. Fix the build errors in the example plugin