### PR TITLE
Update API.hpp

### DIFF
--- a/include/reframework/API.hpp
+++ b/include/reframework/API.hpp
@@ -98,7 +98,7 @@ public:
         return m_param;
     }
 
-    inline const auto sdk() const {
+    inline const REFrameworkSDKData* sdk() const {
         return m_sdk;
     }
 


### PR DESCRIPTION
Hello!
This will fix error below on Microsoft Visual Studio Community 2022 (64-bit) - Current Version 17.7.1

Error	C2327	'reframework::API::m_sdk': is not a type name, static, or enumerator

I just updated and could not compile my project because of that.

