### PR TITLE
Fixed plugin patch version check

### DIFF
--- a/src/mods/PluginLoader.cpp
+++ b/src/mods/PluginLoader.cpp
@@ -712,7 +712,7 @@ std::optional<std::string> PluginLoader::on_initialize() {
             continue;
         }
 
-        if (required_version.patch > g_plugin_version.patch) {
+        if (required_version.patch > g_plugin_version.patch && required_version.minor == g_plugin_version.minor) {
             spdlog::warn("[PluginLoader] Plugin {} desires a newer patch version", name);
             m_plugin_load_warnings.emplace(name, "Desires a newer patch version");
         }


### PR DESCRIPTION
Patch version has no meaning if major and minor version aren't the same as the framework's.