### PR TITLE
Introduce Struct type

### DIFF
--- a/src/mods/tools/ObjectExplorer.cpp
+++ b/src/mods/tools/ObjectExplorer.cpp
@@ -1083,6 +1083,16 @@ void ObjectExplorer::generate_sdk() {
         type_entry["is_generic_type"] = t.is_generic_type();
         type_entry["is_generic_type_definition"] = t.is_generic_type_definition();
 
+#if TDB_VER >= 71
+        if (tdef->element_typeid_TBD != 0) {
+            type_entry["element_type_name"] = init_type(il2cpp_dump, tdb, tdef->element_typeid_TBD)->full_name;
+        }
+#elif TDB_VER >= 69
+        if (tdef->element_typeid != 0) {
+            type_entry["element_type_name"] = init_type(il2cpp_dump, tdb, tdef->element_typeid)->full_name;
+        }
+#endif
+
         if (auto gtd = t.get_generic_type_definition(); gtd != nullptr) {
             type_entry["generic_type_definition"] = gtd->get_full_name();
         }


### PR DESCRIPTION
Note that this is a breaking change.
1. Add a new entry `element_type_name` to `il2cpp_dump.json` if it is an array-like object and TDB >= 69 (tested with MHWilds OBT only).
2. Add the `Struct` data type to the rsz dump. Previously, if it was a `Struct` type, the dumper would unpack it and flatten it into multiple fields. However, for an array of `Struct`, the dumper would skip it. This change will unpack a single `Struct` type as before but will leave the `Struct` type untouched if it is an array of `Struct`, with hardcoded Size and Alignment set to 1, 1.
3. The behavior of `original_type` has changed. For array objects, it points to their element type instead of their own type. For example, for an array of int, it was `"original_type": "System.UInt32[]"` before, but it is `"original_type": "System.UInt32"` after.