### PR TITLE
Add a button to dump only `il2cpp_dump.json`, skipping the `sdk_ida` folder.

### DIFF
--- a/src/mods/tools/ObjectExplorer.cpp
+++ b/src/mods/tools/ObjectExplorer.cpp
@@ -344,7 +344,11 @@ void ObjectExplorer::on_draw_dev_ui() {
         return;
     }
     if (ImGui::Button("Dump SDK")) {
-        std::thread t(&ObjectExplorer::generate_sdk, this);
+        std::thread t(&ObjectExplorer::generate_sdk, this, false);
+        t.detach();
+    }
+    if (ImGui::Button("Dump il2cpp json Only")) {
+        std::thread t(&ObjectExplorer::generate_sdk, this, true);
         t.detach();
     }
 
@@ -989,7 +993,7 @@ void ObjectExplorer::export_deserializer_chain(nlohmann::json& il2cpp_dump, sdk:
 }
 #endif
 
-void ObjectExplorer::generate_sdk() {
+void ObjectExplorer::generate_sdk(const bool justIl2CppJson) {
     // enums
     //auto ref = utility::scan(g_framework->get_module().as<HMODULE>(), "66 C7 40 18 01 01 48 89 05 ? ? ? ?");
     //auto& l = *(std::map<uint64_t, REEnumData>*)(utility::calculate_absolute(*ref + 9));
@@ -2242,9 +2246,11 @@ void ObjectExplorer::generate_sdk() {
 
     spdlog::info("Generating IDA SDK...");
     m_sdk_dump_stage = SdkDumpStage::GENERATE_SDK;
-    
-    genny::ida::transform(sdk);
-    sdk.generate("sdk_ida");
+
+    if (!justIl2CppJson) {
+        genny::ida::transform(sdk);
+        sdk.generate("sdk_ida");
+    }
 
     // Free a couple gigabytes of no longer used memory
     g_stypedb.clear();

--- a/src/mods/tools/ObjectExplorer.hpp
+++ b/src/mods/tools/ObjectExplorer.hpp
@@ -144,7 +144,7 @@ private:
     std::string generate_full_name(sdk::RETypeDB* tdb, uint32_t i);
     void export_deserializer_chain(nlohmann::json& il2cpp_dump, sdk::RETypeDB* tdb, REType* t, std::optional<std::string> real_name = std::nullopt);
 #endif
-    void generate_sdk();
+    void generate_sdk(bool justIl2CppJson);
     void report_sdk_dump_progress(float progress);
 
     void handle_game_object(REGameObject* game_object);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f4317a2b-dc07-45a3-9889-3e2adeef01e0)

Basically just skips the part where it creates the `sdk_ida` folder and it's 350k+ files, which takes forever, and isn't needed for the RSZ json.