### PR TITLE
fix(ScriptRunner): fix deadlock

### DIFF
--- a/src/mods/ScriptRunner.cpp
+++ b/src/mods/ScriptRunner.cpp
@@ -1168,8 +1168,8 @@ void ScriptRunner::spew_error(const std::string& p) {
 
 
 void ScriptRunner::reset_scripts() {
-    std::scoped_lock _{ m_access_mutex };
     std::scoped_lock __{ g_framework->get_hook_monitor_mutex() }; // Stops D3D monitor from attempting to re-hook during long script startups
+    std::scoped_lock _{ m_access_mutex };
 
     {
         std::unique_lock _{ m_script_error_mutex };


### PR DESCRIPTION
Fix deadlock problem when play MHWilds on a high performance machine