### PR TITLE
Fix invoke() in plugin API to support functions with no arguments

### DIFF
--- a/include/reframework/API.hpp
+++ b/include/reframework/API.hpp
@@ -609,8 +609,12 @@ public:
         reframework::InvokeRet invoke(API::ManagedObject* obj, const std::vector<void*>& args) {
             static const auto fn = API::s_instance->sdk()->method->invoke;
             reframework::InvokeRet out{};
-
-            auto result = fn(*this, obj, (void**)&args[0], args.size() * sizeof(void*), &out, sizeof(out));
+            REFrameworkResult result;
+            if (args.size() == 0) {
+                auto result = fn(*this, obj, nullptr, 0, &out, sizeof(out));
+            } else {
+                result = fn(*this, obj, (void**)&args[0], args.size() * sizeof(void*), &out, sizeof(out));
+            }
 
 #ifdef REFRAMEWORK_API_EXCEPTIONS
             if (result != REFRAMEWORK_ERROR_NONE) {

--- a/include/reframework/API.hpp
+++ b/include/reframework/API.hpp
@@ -611,7 +611,7 @@ public:
             reframework::InvokeRet out{};
             REFrameworkResult result;
             if (args.size() == 0) {
-                auto result = fn(*this, obj, nullptr, 0, &out, sizeof(out));
+                result = fn(*this, obj, nullptr, 0, &out, sizeof(out));
             } else {
                 result = fn(*this, obj, (void**)&args[0], args.size() * sizeof(void*), &out, sizeof(out));
             }


### PR DESCRIPTION
Hello developers,

Thank you for your continued efforts to improve this software.

While developing a plugin, I encountered a bug in the `invoke` method of the API. The issue was caused by accessing `args[0]` even when the argument list was empty.

I fixed the issue by adding a guard against empty `args`. I've confirmed that calling functions with no arguments now works correctly.

Here's a minimal test confirming the fix:

```cpp
auto &api = API::get();
const auto tdb = api->tdb();

auto vm_context = api->get_vm_context();

auto manager = api->get_managed_singleton("app.SaveDataManager");
auto f_user_save_data = *manager->get_field<API::ManagedObject *>("_UserSaveData");
auto f_data = *f_user_save_data->get_field<API::ManagedObject *>("_Data");

auto get_count = tdb->find_type("app.savedata.cUserSaveParam[]")->find_method("get_Count");
std::vector<void *> args;
// args ... 0
auto invoke_count_ret = get_count->invoke(f_data, args);
API::get()->log_info("count: %d", invoke_count_ret.dword);
// count: 3

// args ... 1
auto get_item = tdb->find_type("app.savedata.cUserSaveParam[]")->find_method("get_Item");
auto call_ret_obj = get_item->call<API::ManagedObject *>(vm_context, f_data, 0);
auto invoke_get_item_ret = get_item->invoke(f_data, {0});
auto invoke_ret_obj = (API::ManagedObject *)invoke_get_item_ret.ptr;
API::get()->log_info("%s", call_ret_obj == invoke_ret_obj ? "eq" : "ne");
// eq
```
