### PR TITLE
Save stack space while handling errors

### DIFF
--- a/dependencies/lua/src/ldebug.c
+++ b/dependencies/lua/src/ldebug.c
@@ -783,8 +783,11 @@ l_noret luaG_runerror (lua_State *L, const char *fmt, ...) {
   va_start(argp, fmt);
   msg = luaO_pushvfstring(L, fmt, argp);  /* format message */
   va_end(argp);
-  if (isLua(ci))  /* if Lua function, add source:line information */
+  if (isLua(ci)) {  /* if Lua function, add source:line information */
     luaG_addinfo(L, msg, ci_func(ci)->p->source, getcurrentline(ci));
+    setobjs2s(L, L->top - 2, L->top - 1);  /* remove 'msg' from the stack */
+    L->top--;
+  }
   luaG_errormsg(L);
 }
 

--- a/dependencies/lua/src/lvm.c
+++ b/dependencies/lua/src/lvm.c
@@ -656,8 +656,10 @@ void luaV_concat (lua_State *L, int total) {
       /* collect total length and number of strings */
       for (n = 1; n < total && tostring(L, s2v(top - n - 1)); n++) {
         size_t l = vslen(s2v(top - n - 1));
-        if (l_unlikely(l >= (MAX_SIZE/sizeof(char)) - tl))
+        if (l_unlikely(l >= (MAX_SIZE/sizeof(char)) - tl)) {
+          L->top = top - total;  /* pop strings to avoid wasting stack */
           luaG_runerror(L, "string length overflow");
+        }
         tl += l;
       }
       if (tl <= LUAI_MAXSHORTLEN) {  /* is result a short string? */
@@ -672,7 +674,7 @@ void luaV_concat (lua_State *L, int total) {
       setsvalue2s(L, top - n, ts);  /* create result */
     }
     total -= n-1;  /* got 'n' strings to create 1 new */
-    L->top -= n-1;  /* popped 'n' strings and pushed one */
+    L->top = top - (n - 1);  /* popped 'n' strings and pushed one */
   } while (total > 1);  /* repeat until only 1 result left */
 }
 


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in luaG_runerror() that was cloned from lua but did not receive the security patch. The original issue was reported and fixed under https://github.com/lua/lua/commit/42d40581dd919fb134c07027ca1ce0844c670daf.
This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/cve-2022-33099
https://github.com/lua/lua/commit/42d40581dd919fb134c07027ca1ce0844c670daf