### PR TITLE
Allow fs API access to fonts and images directories via $fonts and $images

### DIFF
--- a/src/mods/bindings/FS.cpp
+++ b/src/mods/bindings/FS.cpp
@@ -38,6 +38,22 @@ namespace detail {
 
             return datadir;
         }
+		
+		if (wanted_subdir.find("$fonts") != std::string::npos) {
+            auto datadir = REFramework::get_persistent_dir() / "reframework" / "fonts";
+			
+            ::fs::create_directories(datadir);
+			
+            return datadir;
+        }
+
+        if (wanted_subdir.find("$images") != std::string::npos) {
+            auto datadir = REFramework::get_persistent_dir() / "reframework" / "images";
+			
+            ::fs::create_directories(datadir);
+			
+            return datadir;
+        }
         
         // todo, other subdirs?
     }


### PR DESCRIPTION
updates the fs API to allow scripts to access the $fonts and $images directories using fs.glob and other fs functions.

- Updated get_datadir to recognize $fonts and $images

Tested with Lua scripts to verify correct directory access.