### PR TITLE
Change PAK flags register to fix modded PAKs being 'corrupt' with REF installed.

### DIFF
--- a/src/mods/IntegrityCheckBypass.cpp
+++ b/src/mods/IntegrityCheckBypass.cpp
@@ -659,7 +659,7 @@ void IntegrityCheckBypass::sha3_rsa_code_midhook(safetyhook::Context& context) {
         ENCRYPTED = 0x8
     };
 
-    const auto pak_flags = (PakFlags)context.r8; // Might change, maybe add automated register detection later
+    const auto pak_flags = (PakFlags)context.rax; // Might change, maybe add automated register detection later
 
     if ((pak_flags & PakFlags::ENCRYPTED) != 0) {
         spdlog::info("[IntegrityCheckBypass]: Pak is encrypted, allowing decryption code to run.");


### PR DESCRIPTION
Fixes https://github.com/praydog/REFramework/issues/1410

This was found by @jgammey (jordanclock on Discord) (in [this](https://github.com/praydog/REFramework/issues/1410#issuecomment-3349993444) comment), all I'm doing is making the PR for it.

Edited the file through GH so it auto-added the newline at the end.