### PR TITLE
Plugins: fix C++ API potential crash on get_methods() , get_fields() and get_params()

### DIFF
--- a/include/reframework/API.hpp
+++ b/include/reframework/API.hpp
@@ -531,7 +531,7 @@ public:
             std::vector<API::Method*> methods;
 
             auto num_methods = get_num_methods();
-            if( num_methods<1){
+            if (num_methods < 1) {
                 return {};
             }
 
@@ -553,7 +553,7 @@ public:
             
 
             auto num_fields = get_num_fields();
-            if( num_fields<1){
+            if (num_fields < 1) {
                 return {};
             }
 
@@ -696,7 +696,7 @@ public:
             std::vector<REFrameworkMethodParameter> params;
 
             auto num_params = get_num_params();
-            if (num_params<1){
+            if (num_params < 1) {
                 return {};
             }
 


### PR DESCRIPTION
Found a bug in Api.hpp where , if a `reframework::API::TypeDefinition *`  points to a Type that has no fields ; calling get_fields() crashes the plugin. 

Bug came from :

```
fields.resize(get_num_fields()); //-> can be 0

auto result = fn(*this, (REFrameworkFieldHandle*)&fields[0], fields.size() * sizeof(API::Field*), nullptr); // -> fields[0] is out of bounds
```

I also fixed 2 more places where I found this issue.