### PR TITLE
MHWILDS: Fix REModule struct (tdb81)

### DIFF
--- a/shared/sdk/RETypeDB.cpp
+++ b/shared/sdk/RETypeDB.cpp
@@ -1190,16 +1190,34 @@ std::span<uint32_t> REModule::get_types() const {
 
 std::span<uint32_t> REModule::get_methods() const {
     auto tdb = RETypeDB::get();
+
+#if TDB_VER == 81
+    spdlog::warn("This TDB version does not support REModule::get_methods()");
+    return {};
+#else
     return std::span<uint32_t>{(uint32_t*)tdb->get_bytes(this->methods_start), (size_t)this->methods_count};
+#endif
 }
 
 std::span<uint32_t> REModule::get_instantiated_methods() const {
     auto tdb = RETypeDB::get();
+
+#if TDB_VER == 81
+    spdlog::warn("This TDB version does not support REModule::get_instantiated_methods()");
+    return {};
+#else
     return std::span<uint32_t>{(uint32_t*)tdb->get_bytes(this->method_instantiations_start), (size_t)this->method_instantiations_count};
+#endif
 }
 
 std::span<uint32_t> REModule::get_member_references() const {
     auto tdb = RETypeDB::get();
+
+#if TDB_VER == 81
+    spdlog::warn("This TDB version does not support REModule::get_member_references()");
+    return {};
+#else
     return std::span<uint32_t>{(uint32_t*)tdb->get_bytes(this->member_references_start), (size_t)this->member_references_count};
+#endif
 }
 } // namespace sdk

--- a/shared/sdk/RETypeDB.hpp
+++ b/shared/sdk/RETypeDB.hpp
@@ -444,6 +444,179 @@ struct GenericListData {
 };
 }
 
+namespace tdb81 {
+struct REMethodDefinition;
+struct REMethodImpl;
+struct REField;
+struct REFieldImpl;
+struct REProperty;
+struct RETypeImpl;
+struct REPropertyImpl;
+struct REParameterDef;
+struct REModule;
+
+struct TDB {
+    uint32_t magic;                             
+    uint32_t version;                           
+    uint32_t numTypes;                          
+    uint32_t typesStartOfGenericsProbably;       // I think this is the index of the start of the generics list in the types array (or start of something else)
+    
+    uint32_t unk_int_tdb74;
+    
+    uint32_t numMethods;                        
+    uint32_t numFields;                         
+    uint32_t numTypeImpl;                       
+    uint32_t numFieldImpl;                      
+    uint32_t numMethodImpl;                     
+    uint32_t numPropertyImpl;                   
+    uint32_t numProperties;                     
+    uint32_t numEvents;                         
+
+    uint32_t numParams;                         
+    uint32_t numAttributes;                     
+    int32_t numInitData;                        
+    uint32_t numAttributes2;                    
+    uint32_t numInternStrings;                  
+    uint32_t numModules;                        
+    int32_t devEntry;                           
+    int32_t appEntry;     
+    
+    uint32_t numStringPool;                     
+    uint32_t numBytePool;
+
+    uint32_t padding;
+
+    sdk::REModule* modules;
+    sdk::RETypeDefinition (*types)[93788];      
+    sdk::RETypeImpl (*typesImpl)[256];          
+    sdk::REMethodDefinition (*methods)[703558]; 
+    sdk::REMethodImpl (*methodsImpl)[56756];    
+    sdk::REField (*fields)[1];                  
+    sdk::REFieldImpl (*fieldsImpl)[1];          
+    sdk::REProperty (*properties)[256];         
+    sdk::REPropertyImpl (*propertiesImpl)[1];   
+    void* events;                               
+    sdk::REParameterDef (*params)[10000];       
+    class ::REAttributeDef (*attributes)[2000]; 
+    int32_t (*initData)[19890];                 
+    void* unk;
+    int32_t (*attributes2)[256];                
+    char (*stringPool)[1];                      
+    uint8_t (*bytePool)[256];                   
+    int32_t (*internStrings)[14154];            
+};
+
+static_assert(sizeof(TDB) == 240);
+
+struct REModule {
+    uint32_t guid[4];
+    int32_t unk1;
+    uint32_t unk2;
+    uint16_t major;
+    uint16_t minor;
+    uint16_t build;
+    uint16_t revision;
+    uint32_t flags;
+    int32_t assembly_name_offset; // string
+    int32_t location_offset; // string
+    uint32_t unk3;
+    uint32_t module_name_offset; // string
+    uint32_t unk4;
+    int32_t types_count;
+    int32_t types_start;
+};
+static_assert(sizeof(REModule) == 0x40);
+
+#pragma pack(push, 4)
+struct REParameterDef {
+    uint16_t attributes_id;
+    uint16_t init_data_index;
+    uint32_t name_offset : 30;
+    uint32_t modifier : 2;
+    uint32_t type_id : TYPE_INDEX_BITS;
+    uint32_t flags : (32 - TYPE_INDEX_BITS);
+};
+
+struct REMethodDefinition {
+    uint32_t declaring_typeid : TYPE_INDEX_BITS;
+    uint32_t params_lo : 13;
+    uint32_t impl_id : 19;
+    uint32_t params_hi : 13;
+    int32_t encoded_offset;
+};
+static_assert(sizeof(REMethodDefinition) == 0xC);
+
+struct REMethodImpl {
+    uint16_t attributes_id;
+    int16_t vtable_index;
+    uint16_t flags;
+    uint16_t impl_flags;
+    uint32_t name_offset;
+};
+
+struct RETypeImpl {
+    int32_t name_offset; // 0x0
+    int32_t namespace_offset; // 0x4
+    int32_t field_size; // 0x8
+    int32_t static_field_size; // 0xc
+    uint64_t unk_pad : 33; // 0x10
+    uint64_t num_member_fields : 24; // 0x10
+    uint64_t unk_pad_2 : 7; // 0x10
+    uint16_t num_member_methods; // 0x18
+    int16_t num_native_vtable; // 0x1a
+    int16_t interface_id; // 0x1c
+    char pad_1e[0x12];
+};
+#if TDB_VER >= 71
+static_assert(sizeof(RETypeImpl) == 0x30);
+static_assert(offsetof(RETypeImpl, num_member_methods) == 0x18);
+#endif
+
+struct REProperty {
+    uint64_t impl_id : 20;
+    uint64_t getter : 22;
+    uint64_t setter : 22;
+};
+
+struct REPropertyImpl {
+    uint16_t flags;
+    uint16_t attributes_id;
+    int32_t name_offset;
+};
+#pragma pack(pop)
+
+struct ParamList {
+    uint16_t numParams; //0x0000
+	uint16_t invokeID; //0x0002
+	uint32_t returnType; //0x0004
+	uint32_t params[1]; //0x0008
+};
+
+struct REField {
+    uint64_t declaring_typeid : TYPE_INDEX_BITS;
+    uint64_t impl_id : TYPE_INDEX_BITS;
+    uint64_t field_typeid : TYPE_INDEX_BITS;
+    uint64_t init_data_hi : 6;
+    uint64_t rest2 : 1;
+};
+
+struct REFieldImpl {
+    uint16_t attributes_id;
+    uint16_t unk : 1;
+    uint16_t flags : 15;
+    uint32_t offset : 26;
+    uint32_t init_data_lo : 6;
+    uint32_t name_offset : 28;
+    uint32_t init_data_mid : 4;
+};
+
+struct GenericListData {
+    uint32_t definition_typeid : TYPE_INDEX_BITS;
+    uint32_t num : (32 - TYPE_INDEX_BITS);
+    uint32_t types[1];
+};
+}
+
 namespace tdb74 {
 struct REMethodDefinition;
 struct REMethodImpl;
@@ -505,7 +678,6 @@ struct TDB {
     uint8_t (*bytePool)[256];                   
     int32_t (*internStrings)[14154];            
 };
-
 struct REModule {
     uint32_t guid[4];
     int32_t unk1;
@@ -1354,8 +1526,11 @@ struct TDB {
 #pragma pack(pop)
 }
 
-// TODO?
-struct REModule_ : public sdk::tdb74::REModule {};
+#if TDB_VER == 81
+struct REModule_: public sdk::tdb81::REModule {};
+#else
+struct REModule_: public sdk::tdb74::REModule {};
+#endif
 
 #if TDB_VER >= 84
 struct RETypeDB_ : public sdk::tdb84::TDB {};
@@ -1370,6 +1545,19 @@ struct REProperty : public sdk::tdb84::REProperty {};
 struct REParameterDef : public sdk::tdb84::REParameterDef {};
 struct GenericListData : public sdk::tdb84::GenericListData {};
 using ParamList = sdk::tdb84::ParamList;
+
+#elif TDB_VER >= 81
+struct RETypeDB_ : public sdk::tdb81::TDB {};
+struct REMethodDefinition_ : public sdk::tdb81::REMethodDefinition {};
+struct REMethodImpl : public sdk::tdb81::REMethodImpl {};
+using REField_ = sdk::tdb81::REField;
+struct REFieldImpl : public sdk::tdb81::REFieldImpl {};
+struct RETypeImpl : public sdk::tdb81::RETypeImpl {};
+struct REPropertyImpl : public sdk::tdb81::REPropertyImpl {};
+struct REProperty : public sdk::tdb81::REProperty {};
+struct REParameterDef : public sdk::tdb81::REParameterDef {};
+struct GenericListData : public sdk::tdb81::GenericListData {};
+using ParamList = sdk::tdb81::ParamList;
 
 #elif TDB_VER >= 74
 struct RETypeDB_ : public sdk::tdb74::TDB {};

--- a/shared/sdk/TDBVer.hpp
+++ b/shared/sdk/TDBVer.hpp
@@ -7,7 +7,7 @@
 #elif defined(MHSTORIES3)
 #define TDB_VER 82
 #elif defined(MHWILDS)
-#define TDB_VER 74
+#define TDB_VER 81
 #elif defined(DD2)
 #define TDB_VER 73
 #elif defined(SF6)


### PR DESCRIPTION
Fix #1483 

They seem to have abolished some members in REModule (methods_count, ...), only keeping type_count and type_start

- Create new tdb81 namespace for MHWilds that contains REModule struct changes
- Logging "unsupported" to existing functions of REModule that is affectd by this change

