### PR TITLE
MHWILDS: Fix pak loading for v1.041

### DIFF
--- a/src/mods/IntegrityCheckBypass.cpp
+++ b/src/mods/IntegrityCheckBypass.cpp
@@ -783,8 +783,7 @@ void IntegrityCheckBypass::sha3_rsa_code_midhook(safetyhook::Context& context) {
     spdlog::info("[IntegrityCheckBypass]: RDI: 0x{:X}", context.rdi);
 
     enum PakFlags : uint8_t {
-        ENCRYPTED = 0x8,
-        NO_RSA_CHECK = 0x40
+        ENCRYPTED = 0x8
     };
 
     //const auto pak_flags = (PakFlags)context.rax; // Might change, maybe add automated register detection later


### PR DESCRIPTION
- sha3_code_start changed, add pattern search for it
- Support MHStories3 for new PAK loading changes (its not loading extra PAK)
- Changed some incorrect from the previous PR I made, I changed it, hope you dont mind

## Disassembly and hex new version

<img width="508" height="245" alt="image" src="https://github.com/user-attachments/assets/533660ec-5b28-4400-a388-8f70192492b8" />
<img width="739" height="232" alt="image" src="https://github.com/user-attachments/assets/24b848bc-6903-4481-b054-cbb8819a7f7d" />
<img width="611" height="93" alt="image" src="https://github.com/user-attachments/assets/9b0a44c9-8bbe-4093-91b0-78eaba368f39" />
