### PR TITLE
Get Collections Working in C# API

### DIFF
--- a/csharp-api/AssemblyGenerator/ClassGenerator.cs
+++ b/csharp-api/AssemblyGenerator/ClassGenerator.cs
@@ -38,11 +38,30 @@ public class ClassGenerator {
 
     private static readonly Dictionary<string, (string WrapperName, int ArgCount)> genericCollectionMap = new()
     {
-        ["System.Collections.Generic.List"] = ("REFrameworkNET.Collections._List", 1),
-        ["System.Collections.Generic.IList"] = ("REFrameworkNET.Collections._List", 1),
-        ["System.Collections.Generic.ICollection"] = ("REFrameworkNET.Collections._List", 1),
-        ["System.Collections.Generic.Dictionary"] = ("REFrameworkNET.Collections._Dictionary", 2),
-        ["System.Collections.Generic.IDictionary"] = ("REFrameworkNET.Collections._Dictionary", 2),
+        // List types → IList
+        ["System.Collections.Generic.List"] = ("REFrameworkNET.Collections.IList", 1),
+        ["System.Collections.Generic.IList"] = ("REFrameworkNET.Collections.IList", 1),
+
+        // Collection types → ICollection
+        ["System.Collections.Generic.ICollection"] = ("REFrameworkNET.Collections.ICollection", 1),
+        ["System.Collections.Generic.HashSet"] = ("REFrameworkNET.Collections.ICollection", 1),
+        ["System.Collections.Generic.LinkedList"] = ("REFrameworkNET.Collections.ICollection", 1),
+        ["System.Collections.Generic.Queue"] = ("REFrameworkNET.Collections.IReadOnlyCollection", 1),
+        ["System.Collections.Generic.Stack"] = ("REFrameworkNET.Collections.IReadOnlyCollection", 1),
+
+        // Dictionary types → IDictionary
+        ["System.Collections.Generic.Dictionary"] = ("REFrameworkNET.Collections.IDictionary", 2),
+        ["System.Collections.Generic.IDictionary"] = ("REFrameworkNET.Collections.IDictionary", 2),
+        ["System.Collections.Generic.SortedList"] = ("REFrameworkNET.Collections.IDictionary", 2),
+
+        // Enumerable/Enumerator
+        ["System.Collections.Generic.IEnumerable"] = ("REFrameworkNET.Collections.IEnumerable", 1),
+        ["System.Collections.Generic.IEnumerator"] = ("REFrameworkNET.Collections.IEnumerator", 1),
+
+        // Read-only types
+        ["System.Collections.Generic.IReadOnlyCollection"] = ("REFrameworkNET.Collections.IReadOnlyCollection", 1),
+        ["System.Collections.Generic.IReadOnlyList"] = ("REFrameworkNET.Collections.IReadOnlyList", 1),
+        ["System.Collections.Generic.IReadOnlyDictionary"] = ("REFrameworkNET.Collections.IReadOnlyDictionary", 2),
     };
 
     public TypeDeclarationSyntax? TypeDeclaration {

--- a/csharp-api/AssemblyGenerator/Generator.cs
+++ b/csharp-api/AssemblyGenerator/Generator.cs
@@ -905,82 +905,6 @@ public class AssemblyGenerator {
         return null;
     }
 
-    private static REFrameworkNET.Compiler.DynamicAssemblyBytecode? GenerateCollectionWrappers() {
-        string sourceCode = @"
-#nullable enable
-namespace REFrameworkNET.Collections
-{
-    public interface _IEnumerator<T>
-    {
-        T Current { get; }
-        bool MoveNext();
-    }
-
-    public interface _List<T>
-    {
-        int Count { get; }
-        T this[int index] { get; set; }
-        void Add(T item);
-        void Clear();
-        bool Contains(T item);
-        bool Remove(T item);
-        int IndexOf(T item);
-        void Insert(int index, T item);
-        void RemoveAt(int index);
-        _IEnumerator<T> GetEnumerator();
-    }
-
-    public interface _Dictionary<TKey, TValue>
-    {
-        int Count { get; }
-        TValue this[TKey key] { get; set; }
-        bool ContainsKey(TKey key);
-        void Add(TKey key, TValue value);
-        bool Remove(TKey key);
-        void Clear();
-    }
-}
-";
-
-        var syntaxTreeParseOption = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12);
-        var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode, syntaxTreeParseOption);
-
-        var references = REFrameworkNET.Compiler.GenerateExhaustiveMetadataReferences(
-            typeof(REFrameworkNET.API).Assembly, new List<Assembly>());
-
-        var csoptions = new CSharpCompilationOptions(
-            OutputKind.DynamicallyLinkedLibrary,
-            optimizationLevel: OptimizationLevel.Release,
-            assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default,
-            platform: Platform.X64,
-            allowUnsafe: true);
-
-        CSharpCompilation compilation = CSharpCompilation.Create("Collections")
-            .WithOptions(csoptions)
-            .AddReferences(references)
-            .AddSyntaxTrees(syntaxTree);
-
-        using (var ms = new MemoryStream()) {
-            var result = compilation.Emit(ms);
-
-            if (!result.Success) {
-                foreach (Diagnostic diagnostic in result.Diagnostics) {
-                    Console.WriteLine($"Collections wrapper error: {diagnostic.Id}: {diagnostic.GetMessage()}");
-                }
-                REFrameworkNET.API.LogError("Failed to compile Collections wrappers");
-                return null;
-            }
-
-            ms.Seek(0, SeekOrigin.Begin);
-            REFrameworkNET.API.LogInfo("Successfully compiled Collections wrappers");
-
-            return new REFrameworkNET.Compiler.DynamicAssemblyBytecode {
-                Bytecode = ms.ToArray(),
-                AssemblyName = "Collections"
-            };
-        }
-    }
-
     public static List<REFrameworkNET.Compiler.DynamicAssemblyBytecode> MainImpl() {
         var tdb = REFrameworkNET.API.GetTDB();
         Il2CppDump.FillTypeExtensions(tdb);
@@ -1000,13 +924,6 @@ namespace REFrameworkNET.Collections
         }
 
         List<REFrameworkNET.Compiler.DynamicAssemblyBytecode> bytecodes = [];
-
-        // Generate collection wrapper interfaces before any game module
-        // so all modules can reference _List<T>, _Dictionary<TKey,TValue>, etc.
-        var collectionsWrappers = GenerateCollectionWrappers();
-        if (collectionsWrappers != null) {
-            bytecodes.Add(collectionsWrappers);
-        }
 
         foreach (Module module in modules) {
             var assemblyName = module.AssemblyName;

--- a/csharp-api/REFrameworkNET/API.hpp
+++ b/csharp-api/REFrameworkNET/API.hpp
@@ -14,6 +14,7 @@
 #include "NativeObject.hpp"
 
 #include "Callbacks.hpp"
+#include "Collections.hpp"
 
 namespace reframework {
 class API;

--- a/csharp-api/REFrameworkNET/Collections.hpp
+++ b/csharp-api/REFrameworkNET/Collections.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+namespace REFrameworkNET {
+namespace Collections {
+
+generic <typename T>
+public interface class IEnumerator {
+    property T Current { T get(); }
+    bool MoveNext();
+};
+
+generic <typename T>
+public interface class IEnumerable {
+    IEnumerator<T>^ GetEnumerator();
+};
+
+generic <typename T>
+public interface class ICollection {
+    property int Count { int get(); }
+    void Add(T item);
+    void Clear();
+    bool Contains(T item);
+    bool Remove(T item);
+    IEnumerator<T>^ GetEnumerator();
+};
+
+generic <typename T>
+public interface class IList {
+    property int Count { int get(); }
+    property T default[int] { T get(int index); void set(int index, T value); }
+    void Add(T item);
+    void Clear();
+    bool Contains(T item);
+    bool Remove(T item);
+    int IndexOf(T item);
+    void Insert(int index, T item);
+    void RemoveAt(int index);
+    IEnumerator<T>^ GetEnumerator();
+};
+
+generic <typename T>
+public interface class IReadOnlyCollection {
+    property int Count { int get(); }
+    IEnumerator<T>^ GetEnumerator();
+};
+
+generic <typename T>
+public interface class IReadOnlyList {
+    property int Count { int get(); }
+    property T default[int] { T get(int index); }
+    IEnumerator<T>^ GetEnumerator();
+};
+
+generic <typename TKey, typename TValue>
+public interface class IDictionary {
+    property int Count { int get(); }
+    property TValue default[TKey] { TValue get(TKey key); void set(TKey key, TValue value); }
+    bool ContainsKey(TKey key);
+    void Add(TKey key, TValue value);
+    bool Remove(TKey key);
+    void Clear();
+    property ICollection<TKey>^ Keys { ICollection<TKey>^ get(); }
+    property ICollection<TValue>^ Values { ICollection<TValue>^ get(); }
+};
+
+generic <typename TKey, typename TValue>
+public interface class IReadOnlyDictionary {
+    property int Count { int get(); }
+    property TValue default[TKey] { TValue get(TKey key); }
+    bool ContainsKey(TKey key);
+    property IEnumerable<TKey>^ Keys { IEnumerable<TKey>^ get(); }
+    property IEnumerable<TValue>^ Values { IEnumerable<TValue>^ get(); }
+};
+
+} // namespace Collections
+} // namespace REFrameworkNET


### PR DESCRIPTION
This PR is to add a simple wrapper for collections to get them working.

This is a snippet from a simple mod I used to test in RE4:
```cs
using REFrameworkNET.Collections;
//...
chainsaw.gui.inventory.CsInventory csInventory = invController._CsInventory;
IList<CsInventoryItem> invItems = csInventory._InventoryItems;

foreach (CsInventoryItem item in invItems)
{
    // work with the item...
}

// or use a traditional loop

for (int i = 0; i < invItems.Count; ++i)
{
    CsInventoryItem item = invItems[i];
    // work with the item...
}
```