### PR TITLE
Fix RE9 build: add missing bdshemu link target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17860,6 +17860,8 @@ if(REF_BUILD_FRAMEWORK AND CMAKE_SIZEOF_VOID_P EQUAL 8) # build-framework
 	target_link_libraries(RE9 PUBLIC
 		${CMKR_TARGET}SDK
 		utility
+        bddisasm
+        bdshemu
 		asmjit::asmjit
 		nlohmann_json
 		spdlog


### PR DESCRIPTION
Adds bddisasm and bdshemu to RE9 target_link_libraries. Fixes LNK2019 unresolved external symbol ShemuEmulate from Dev Release #1296 (commit 5785f07).

Tested and verified working on RE9 v1.1.2.0 (Steam NA/English). All critical integrity bypass patches succeed. Published as a community build on Nexus Mods with 850+ downloads confirming functionality.