### PR TITLE
Star Force Legacy Collection support

### DIFF
--- a/cmake.toml
+++ b/cmake.toml
@@ -63,6 +63,7 @@ REF_BUILD_SF6_SDK = false
 REF_BUILD_DD2_SDK = false
 REF_BUILD_MHWILDS_SDK = false
 REF_BUILD_MHSTORIES3_SDK = false
+REF_BUILD_STARFORCE_SDK = false
 REF_BUILD_RE9_SDK = false
 REF_BUILD_PRAGMATA_SDK = false
 REF_BUILD_FRAMEWORK = { value = true }
@@ -85,6 +86,7 @@ build-sf6-sdk = "REF_BUILD_SF6_SDK OR REF_BUILD_FRAMEWORK"
 build-dd2-sdk = "REF_BUILD_DD2_SDK OR REF_BUILD_FRAMEWORK"
 build-mhwilds-sdk = "REF_BUILD_MHWILDS_SDK OR REF_BUILD_FRAMEWORK"
 build-mhstories3-sdk = "REF_BUILD_MHSTORIES3_SDK OR REF_BUILD_FRAMEWORK"
+build-starforce-sdk = "REF_BUILD_STARFORCE_SDK OR REF_BUILD_FRAMEWORK"
 build-re9-sdk = "REF_BUILD_RE9_SDK OR REF_BUILD_FRAMEWORK"
 build-pragmata-sdk = "REF_BUILD_PRAGMATA_SDK OR REF_BUILD_FRAMEWORK"
 build-framework-dependencies = "REF_BUILD_DEPENDENCIES AND CMAKE_SIZEOF_VOID_P EQUAL 8"
@@ -404,6 +406,14 @@ compile-definitions = ["MHSTORIES3", "REENGINE_PACKED", "REENGINE_AT"]
 condition = "build-mhstories3-sdk"
 
 [target.MHSTORIES3]
+type = "game"
+
+[target.STARFORCESDK]
+type = "sdk"
+compile-definitions = ["STARFORCE", "REENGINE_PACKED", "REENGINE_AT"]
+condition = "build-starforce-sdk"
+
+[target.STARFORCE]
 type = "game"
 
 [target.RE9SDK]

--- a/shared/sdk/ReClass.hpp
+++ b/shared/sdk/ReClass.hpp
@@ -16,6 +16,8 @@
 #include "ReClass_Internal_MHWILDS.hpp" // Copy of DD2 (for now)
 #elif defined(MHSTORIES3)
 #include "ReClass_Internal_MHSTORIES3.hpp" // Copy of MHWILDS (for now)
+#elif defined(STARFORCE)
+#include "ReClass_Internal_MHWILDS.hpp" // Copy of MHWILDS (for now)
 #elif defined(DD2)
 #include "ReClass_Internal_DD2.hpp" // Copy of SF6
 #elif defined(SF6)

--- a/shared/sdk/TDBVer.hpp
+++ b/shared/sdk/TDBVer.hpp
@@ -6,6 +6,8 @@
 #define TDB_VER 84
 #elif defined(RE9)
 #define TDB_VER 83
+#elif defined(STARFORCE)
+#define TDB_VER 78
 #elif defined(MHSTORIES3)
 #define TDB_VER 82
 #elif defined(MHWILDS)
@@ -68,6 +70,10 @@ using RETypeDefinition_ = sdk::RETypeDefVersion84;
 #define TYPE_INDEX_BITS 19
 #define FIELD_BITS 20
 using RETypeDefinition_ = sdk::RETypeDefVersion83;
+#elif defined(STARFORCE)
+#define TYPE_INDEX_BITS 19
+#define FIELD_BITS 19
+using RETypeDefinition_ = sdk::RETypeDefVersion74;
 #elif defined(MHSTORIES3)
 #define TYPE_INDEX_BITS 19
 #define FIELD_BITS 20

--- a/src/REFramework.hpp
+++ b/src/REFramework.hpp
@@ -131,6 +131,8 @@ public:
         return "dd2";
     #elif defined(MHWILDS)
         return "mhwilds";
+    #elif defined(STARFORCE)
+        return "starforce";
     #elif defined(MHSTORIES3)
         return "mhstories3";
     #elif defined(PRAGMATA)


### PR DESCRIPTION
This fixes Star Force Legacy Collection.

- Add STARFORCE build target for MegaMan StarForce Legacy Collection
- TDB_VER=78, TYPE_INDEX_BITS=19, FIELD_BITS=19
- Uses RETypeDefVersion74 and ReClass_Internal_MHWILDS layout
- STARFORCESDK with REENGINE_PACKED and REENGINE_AT defines