### PR TITLE
Improve sharpness removal: re-enable Sharpness field...

### DIFF
--- a/scripts/re2_sharpness_removal.lua
+++ b/scripts/re2_sharpness_removal.lua
@@ -6,35 +6,25 @@ local statics = require("utility/Statics")
 
 local TAAStrength = statics.generate("via.render.ToneMapping.TemporalAA", true)
 
-local wanted_sharpness = 1.0
+local wanted_sharpness = 0.0
 local wanted_sharpness_enable = false
 local wanted_jitter = false
-local debug_disable = false
 
 local prev_filter_self = nil
 
 local function on_pre_apply_layer_param(args)
     prev_filter_self = args[2]
-
-    if debug_disable then
-        return sdk.PreHookResult.SKIP_ORIGINAL
-    end
-
     return sdk.PreHookResult.CALL_ORIGINAL
 end
 
 local function on_post_apply_layer_param(retval)
-    if debug_disable then
-        return retval
-    end
-
     local tonemapping_controller = sdk.to_managed_object(prev_filter_self)
     local current_param = tonemapping_controller:get_field("CurrentParam")
 
     if current_param ~= nil then
         current_param:set_field("EchoEnabled", not wanted_jitter)
         current_param:set_field("TemporalAA", wanted_sharpness_enable and TAAStrength.Strong or TAAStrength.Disable)
-        --current_param:set_field("Sharpness", wanted_sharpness) -- doesn't seem to change anything...
+        current_param:set_field("Sharpness", wanted_sharpness)
     end
 
     return retval
@@ -45,12 +35,15 @@ sdk.hook(tonemap_controller_type:get_method("applyLayerParam"), on_pre_apply_lay
 
 re.on_draw_ui(function()
     if imgui.tree_node("Sharpness Settings") then
-        local changed = false
+        local changed_enable, changed_slider, changed_jitter = false, false, false
 
-        --changed, wanted_sharpness = imgui.drag_float("Sharpness", wanted_sharpness, 0.01, 0.0, 5.0)
-        changed, wanted_sharpness_enable = imgui.checkbox("Sharpness Enabled", wanted_sharpness_enable)
-        changed, wanted_jitter = imgui.checkbox("TAA Jitter Enabled", wanted_jitter)
-        --changed, debug_disable = imgui.checkbox("Debug Disable", debug_disable)
+        changed_enable, wanted_sharpness_enable = imgui.checkbox("Sharpness Enabled", wanted_sharpness_enable)
+
+        if changed_enable then
+            wanted_sharpness = wanted_sharpness_enable and 1.0 or 0.0
+        end
+
+        changed_jitter, wanted_jitter = imgui.checkbox("TAA Jitter Enabled", wanted_jitter)
 
         imgui.tree_pop()
     end


### PR DESCRIPTION
...override and change default behavior to sharpness off

- Uncomment and enable Sharpness field to apply sharpness values
- UI toggle sets sharpness to 1.0 when enabled, 0.0 when disabled. Defaults to disable.
- Removed broken + redundant slider.
- Initialize wanted_sharpness to 0.0 to conform with user expected behavior when using sharpness removal
- Remove debug_disable flag for simpler code

This ensures intuitive default behavior when moved to autorun or manually run and simplifies user-configuration.