### PR TITLE
PAK fix Pragmata related

### DIFF
--- a/reversing/rsz/emulation-dumper.py
+++ b/reversing/rsz/emulation-dumper.py
@@ -583,7 +583,7 @@ def hook_code(emu, address, size, frame):
                                     "align": 1,
                                     "string": False,
                                     "list": False,
-                                    "offset": previous_member_offset
+                                    "offset": previous_member_offset + probale_element_size
                                 })
 
                         frame["last_deserialize_cur"] = val

--- a/src/mods/FaultyFileDetector.cpp
+++ b/src/mods/FaultyFileDetector.cpp
@@ -315,18 +315,9 @@ bool FaultyFileDetector::scan_resource_process_parse_and_hook() {
                 // TODO: For now only one exists, but if multiple exists we should hook them all, just need to figure out how to differentiate them
                 spdlog::info("[FaultyFileDetector]: Found possible get next resource to process function at 0x{:X}", possible_get_next_resource_to_process_call.value());
 
-                // Follow the failure function
-                const int scan_resource_path_usage_length = 1024;
-                auto using_resource_path_offset = utility::scan_displacement_reference(possible_get_next_resource_to_process_call.value(), scan_resource_path_usage_length, str_offset.value());
-
-                std::uint8_t *resource_stream_failed_offset = nullptr;
-
-                if (using_resource_path_offset.has_value()) {
-                    // Skip the displacement value
-                    auto next_instr = using_resource_path_offset.value() + 4;
-
-                    const int scan_resource_stream_failed_length = 2048;
-                    utility::exhaustive_decode((uint8_t*)next_instr, scan_resource_stream_failed_length, std::bind(&FaultyFileDetector::scan_for_resource_open_failed_hook, this, std::placeholders::_1));
+                auto bounds = utility::determine_function_bounds(possible_get_next_resource_to_process_call.value());
+                if (bounds.has_value()) {
+                    utility::exhaustive_decode((uint8_t*)bounds->start, bounds->end - bounds->start, std::bind(&FaultyFileDetector::scan_for_resource_open_failed_hook, this, std::placeholders::_1));
                 }
 
                 if (m_resource_open_failed_addr) {
@@ -340,11 +331,7 @@ bool FaultyFileDetector::scan_resource_process_parse_and_hook() {
                     m_resource_open_failed_hook = std::move(hook);
                     break;
                 } else {
-                    if (using_resource_path_offset.has_value()) {
-                        spdlog::warn("[FaultyFileDetector]: Failed to find resource stream failed check after using resource path at 0x{:X}", (uintptr_t)using_resource_path_offset.value());
-                    } else {
-                        spdlog::warn("[FaultyFileDetector]: Failed to find usage of resource path string at 0x{:X}", (uintptr_t)possible_get_next_resource_to_process_call.value());
-                    }
+                    spdlog::warn("[FaultyFileDetector]: Failed to find resource stream failed check after using resource path at 0x{:X}", (uintptr_t)possible_get_next_resource_to_process_call.value());
                 }
             }
         }

--- a/src/mods/IntegrityCheckBypass.cpp
+++ b/src/mods/IntegrityCheckBypass.cpp
@@ -858,11 +858,7 @@ void IntegrityCheckBypass::restore_unencrypted_paks() {
 
 #if TDB_VER >= 81
     // Find function start may
-    auto pak_load_check_start = utility::scan(game, "41 57 41 56 41 55 41 54 56 57 55 53 48 81 EC ? ? ? ? 48 89 CE 48 8B 05 ? ? ? ? 48 31 E0 48 89 84 24 ? ? ? ? 48 8B 81 ? ? ? ? 48 C1 E8 10");
-
-    if (!pak_load_check_start) {
-        pak_load_check_start = utility::find_function_start_unwind(*sha3_code_start);
-    }
+    auto pak_load_check_start = utility::find_function_start_unwind(*pak_load_fn);
 
     if (pak_load_check_start) {
         spdlog::info("[IntegrityCheckBypass]: Found pak_load_check_function @ 0x{:X}, hook!", (uintptr_t)*pak_load_check_start);
@@ -902,29 +898,71 @@ void IntegrityCheckBypass::restore_unencrypted_paks() {
                 spdlog::info("[IntegrityCheckBypass]: Found reference to re_chunk string at 0x{:X}, assuming this is the start of using patch version", where_compare_str->addr);
                 patch_version_start = where_compare_str->addr;
 
-                auto previous_instructions = utility::get_disassembly_behind(*patch_version_start);
-                
-                // Check if previous instruction is a mov, that should be our register
-                if (!previous_instructions.empty()) {
-#if defined(RE9)
-                    s_patch_version_reg_index = NDR_RDI; // RE9 v1.0.0.0
-                    spdlog::info("[IntegrityCheckBypass]: patch_version_reg_index set to {} based on RE9 knowledge", s_patch_version_reg_index);
-#else
-                    for (auto insn_begin = previous_instructions.rbegin(); insn_begin != previous_instructions.rend(); ++insn_begin) {
-                        auto previous_instruction = *insn_begin;
+                bool found_reg = false;
 
-                        if ((previous_instruction.instrux.Instruction == ND_INS_MOV || previous_instruction.instrux.Instruction == ND_INS_MOVZX) && previous_instruction.instrux.Operands[0].Type == ND_OP_REG) {
-                            s_patch_version_reg_index = previous_instruction.instrux.Operands[0].Info.Register.Reg;
-                            spdlog::info("[IntegrityCheckBypass]: patch_version_reg_index set to {} through fallback method", s_patch_version_reg_index);
+                // No reliable way to detect the patch version register, rather then finding the last loop point of the function
+                auto bounds = utility::determine_function_bounds(*load_patch_func);
+                if (bounds) {
+                    auto blocks = utility::collect_linear_blocks(bounds->start, bounds->end);
+                    for (auto rite = blocks.rbegin(); rite != blocks.rend(); ++rite) {
+                        auto& block = *rite;
 
-                            break;
-                        } else {
-                            spdlog::error("[IntegrityCheckBypass]: Previous instruction is not a MOV or MOVZX with register operand, cannot determine patch_version_reg_index through fallback method!");
+                        auto first_instruction = utility::decode_one((uint8_t*)block.start);
+                        auto second_instruction = first_instruction ? utility::decode_one((uint8_t*)(block.start + first_instruction->Length)) : std::nullopt;
+                        
+                        if (!first_instruction || !second_instruction) {
+                            continue;
+                        }
+
+                        auto total_length = first_instruction->Length + second_instruction->Length;
+                        if (block.start + total_length > block.end) {
+                            continue;
+                        }
+
+                        if (first_instruction->Instruction == ND_INS_INC && second_instruction->Instruction == ND_INS_CMP
+                            && first_instruction->Operands[0].Type == ND_OP_REG && second_instruction->Operands[0].Type == ND_OP_REG
+                            && second_instruction->Operands[1].Type == ND_OP_REG) {
+                            // Iterate further to confirm a branch exists
+                            auto next_instruction = utility::decode_one((uint8_t*)(block.start + total_length));
+                            bool branch_found = false;
+
+                            while (next_instruction) {
+                                if (next_instruction->BranchInfo.IsBranch && next_instruction->BranchInfo.IsConditional) {
+                                    branch_found = true;
+                                    break;
+                                }
+                                total_length += next_instruction->Length;
+                                if (block.start + total_length > block.end) {
+                                    break;
+                                }
+                                next_instruction = utility::decode_one((uint8_t*)(block.start + total_length));
+                            }
+
+                            if (branch_found) {
+                                spdlog::info("[IntegrityCheckBypass]: Found loop at 0x{:X}, assuming patch version check loops back here", block.start);
+
+                                // Get the register being compared in the CMP instruction
+                                auto inc_register = first_instruction->Operands[0].Info.Register.Reg;
+                                auto cmp_op0_register = second_instruction->Operands[0].Info.Register.Reg;
+                                auto cmp_op1_register = second_instruction->Operands[1].Info.Register.Reg;
+
+                                if (inc_register == cmp_op0_register) {
+                                    s_patch_version_reg_index = cmp_op1_register;
+                                } else {
+                                    s_patch_version_reg_index = cmp_op0_register;
+                                }
+
+                                spdlog::info("[IntegrityCheckBypass]: patch_version_reg_index set to {} (fallback method)", s_patch_version_reg_index);
+
+                                found_reg = true;
+                                break;
+                            }
                         }
                     }
-#endif
-                } else {
-                    spdlog::error("[IntegrityCheckBypass]: Could not find previous instructions for patch_version_reg_index fallback method!");
+                }
+
+                if (!found_reg) {
+                    spdlog::error("[IntegrityCheckBypass]: Could not determine patch_version_reg_index through fallback method either!");
                 }
             }
         }
@@ -2358,48 +2396,34 @@ static utility::ExhaustionResult do_exhaustion_scan_create_file_refs(utility::Ex
 void IntegrityCheckBypass::find_try_hook_via_file_load_win32_create_file(uintptr_t pak_load_func_addr) {
 #if ENABLE_PAK_DIRECTORY_LOAD
     // Find the first call instruction, thats our opening PAK file function
-    const int INSTRUCTION_SEARCH_COUNT = 240;
+    const int INSTRUCTION_SEARCH_COUNT = 520;
 
     uint8_t *open_stream_func_addr = 0;
     uint8_t *search_current = (uint8_t*)pak_load_func_addr;
 
-    for (int i = 0; i < INSTRUCTION_SEARCH_COUNT; i++) {
-        auto instr = utility::decode_one(search_current);
-        if (!instr) {
-            continue;
-        }
+    uintptr_t last_call = 0;
 
-#if defined(RE9) // Super ultra dirty hack (TM) for RE9 v1.0.0.0
-        if (instr->Instruction == ND_INS_CALLNR) {
-            spdlog::info("[IntegrityCheckBypass]: Found call to stream open function at 0x{:X}!", (uintptr_t)search_current);
-
-            if (auto resolved_opt = utility::resolve_displacement((uintptr_t)search_current)) {
-                open_stream_func_addr = (uint8_t*)*resolved_opt;
-                break;
+    // The only clear indication of this function for now is that it is the first call function that checks its boolean result
+    utility::linear_decode(search_current, INSTRUCTION_SEARCH_COUNT, [&](utility::ExhaustionContext& ctx) -> bool {
+        auto &instr = ctx.instrux;
+        if (instr.Instruction == ND_INS_CALLNR) {
+            auto displacement_result = utility::resolve_displacement(ctx.addr);
+            if (displacement_result) {
+                last_call = *displacement_result;
             }
         }
-#else
-        if (instr->Instruction == ND_INS_CALLNR) {
-            // Is next instruction testing if the result is zero/non-zero? If so, this is likely the call that opens the file stream, since it checks if the handle is valid.
-            auto next_instr = utility::decode_one(search_current + instr->Length);
-            if (next_instr && next_instr->Instruction == ND_INS_TEST) {
-                if (next_instr->Operands[0].Type == ND_OP_REG && next_instr->Operands[0].Info.Register.Reg == NDR_RAX
-                    && next_instr->Operands[1].Type == ND_OP_REG && next_instr->Operands[1].Info.Register.Reg == NDR_RAX) {
-                    spdlog::info("[IntegrityCheckBypass]: Found call to stream open function at 0x{:X}!", (uintptr_t)search_current);
- 
-                    if (auto resolved_opt = utility::resolve_displacement((uintptr_t)search_current)) {
-                        open_stream_func_addr = (uint8_t*)*resolved_opt;
-                        break;
-                    }
-                } else {
-                    continue;
-                }
+
+        if (instr.Instruction == ND_INS_TEST) {
+            if (instr.Operands[0].Type == ND_OP_REG && instr.Operands[0].Info.Register.Reg == NDR_RAX
+                && instr.Operands[1].Type == ND_OP_REG && instr.Operands[1].Info.Register.Reg == NDR_RAX) {
+                spdlog::info("[IntegrityCheckBypass]: Found call to stream open function at 0x{:X}!", (uintptr_t)last_call);
+                open_stream_func_addr = (uint8_t*)last_call;
+                return false;
             }
         }
-#endif
 
-        search_current += instr->Length;
-    }
+        return true;
+    });
 
     if (open_stream_func_addr == nullptr) {
         spdlog::error("[IntegrityCheckBypass]: Could not find call to stream open function!");

--- a/src/mods/LooseTextureLoader.cpp
+++ b/src/mods/LooseTextureLoader.cpp
@@ -348,7 +348,9 @@ void LooseTextureLoader::find_get_path_to_resource_func() {
 
     spdlog::info("[LooseTextureLoader]: Found path format string at 0x{:X}", *format_str);
 
-    constexpr int EXPECTED_FIRST_MEM_DISP = 0x58;
+    constexpr int EXPECTED_FIRST_MEM_DISP = 1164;
+    constexpr int EXPECTED_SECOND_MEM_DISP = 1136;
+
     auto format_refs = utility::scan_displacement_references(game, *format_str);
 
     for (auto ref : format_refs) {
@@ -358,50 +360,50 @@ void LooseTextureLoader::find_get_path_to_resource_func() {
         auto func_bounds = utility::determine_function_bounds(*func);
         if (!func_bounds) continue;
 
-        bool found_first_mov_mem_disp = false;
-        bool first_mov_mem_disp_is_valid = false;
-        int cmp_12_count = 0;
+        bool specific_cmp_with_12_found = false;
+        bool specific_second_mov_found = false;
 
         utility::exhaustive_decode((uint8_t*)*func, func_bounds->end - func_bounds->start, [&](utility::ExhaustionContext& ctx) -> utility::ExhaustionResult {
             if (ctx.instrux.Category == ND_CAT_CALL) {
                 return utility::ExhaustionResult::STEP_OVER;
             }
 
-            // Check first MOV/MOVZX with non-zero memory displacement in second operand
-            if (!found_first_mov_mem_disp && (ctx.instrux.Instruction == ND_INS_MOV || ctx.instrux.Instruction == ND_INS_MOVZX)) {
-                if (ctx.instrux.ExpOperandsCount >= 2) {
-                    const auto& op = ctx.instrux.Operands[1];
-                    if (op.Type == ND_OP_MEM && op.Info.Memory.HasDisp && op.Info.Memory.Disp != 0) {
-                        found_first_mov_mem_disp = true;
-                        first_mov_mem_disp_is_valid = (op.Info.Memory.Disp == EXPECTED_FIRST_MEM_DISP);
-                    }
-                }
-            }
-
             // Count CMP instructions with immediate 12
-            if (ctx.instrux.Instruction == ND_INS_CMP) {
-                for (size_t i = 0; i < ctx.instrux.ExpOperandsCount; ++i) {
-                    if (ctx.instrux.Operands[i].Type == ND_OP_IMM && ctx.instrux.Operands[i].Info.Immediate.Imm == 12) {
-                        cmp_12_count++;
-                        break;
+            if (!specific_cmp_with_12_found && ctx.instrux.Instruction == ND_INS_CMP) {
+                if (ctx.instrux.OperandsCount >= 2) {
+                    const auto& op1 = ctx.instrux.Operands[0];
+                    const auto& op2 = ctx.instrux.Operands[1];
+
+                    if ((op1.Type == ND_OP_MEM && op1.Info.Memory.Disp == EXPECTED_FIRST_MEM_DISP &&
+                         op2.Type == ND_OP_IMM && op2.Info.Immediate.Imm == 12) ||
+                        (op1.Type == ND_OP_IMM && op1.Info.Immediate.Imm == 12 &&
+                         op2.Type == ND_OP_MEM && op2.Info.Memory.Disp == EXPECTED_FIRST_MEM_DISP)) {
+                        specific_cmp_with_12_found = true;
                     }
                 }
             }
 
-            if (found_first_mov_mem_disp && !first_mov_mem_disp_is_valid) {
-                return utility::ExhaustionResult::BREAK;
+            if (specific_cmp_with_12_found && !specific_second_mov_found) {
+                if (ctx.instrux.Instruction == ND_INS_MOV || ctx.instrux.Instruction == ND_INS_MOVZX) {
+                    if (ctx.instrux.OperandsCount >= 2) {
+                        const auto& src = ctx.instrux.Operands[1];
+                        if (src.Type == ND_OP_MEM && src.Info.Memory.Disp == EXPECTED_SECOND_MEM_DISP) {
+                            specific_second_mov_found = true;
+                        }
+                    }
+                }
             }
 
-            if (first_mov_mem_disp_is_valid && cmp_12_count >= 1) {
+            if (specific_cmp_with_12_found && specific_second_mov_found) {
                 return utility::ExhaustionResult::BREAK;
             }
 
             return utility::ExhaustionResult::CONTINUE;
         });
 
-        if (first_mov_mem_disp_is_valid && cmp_12_count >= 1) {
+        if (specific_cmp_with_12_found && specific_second_mov_found) {
             m_get_native_path_to_resource_func = (GetNativeResourcePath)*func;
-            spdlog::info("[LooseTextureLoader]: Found get_path_to_resource at 0x{:X} (cmp 12 count: {})", *func, cmp_12_count);
+            spdlog::info("[LooseTextureLoader]: Found get_path_to_resource at 0x{:X}", *func);
             return;
         }
     }


### PR DESCRIPTION
Tested on MHWilds and Pragmata, removed some hardcoded cases on RE9 (need test)

- FaultyFileDetector: Fix resource stream failed function not found
- IntegrityCheckBypass: A more reliable way to detect patch_version register, fix pak mod loading issues on Pragmata
- IntegrityCheckBypass: A more reliable way to detect stream open function (remove RE9 hardcode case)
- LooseTextureLoader: A more reliable way to find get_path_to_resource, fix texture cache toggle for loose texture loading