### PR TITLE
Fix frame-pacing micro-stutter with DLSS-G / FSR3 / XeSS Frame Generation

### DIFF
--- a/src/D3D12Hook.hpp
+++ b/src/D3D12Hook.hpp
@@ -91,7 +91,38 @@ public:
     }
     
     bool is_framegen_swapchain() const {
-        return m_using_frame_generation_swapchain;
+        if (m_using_frame_generation_swapchain) {
+            return true;
+        }
+
+        // RTTI-based detection on the dummy swapchain can fail (seen on
+        // Pragmata: "Failed to get type info: unknown exception"), which
+        // leaves m_using_frame_generation_swapchain false even though the
+        // game's real swapchain IS being interposed for frame generation.
+        // Fall back to signals that don't depend on RTTI:
+        //   1. Streamline's linkSwapchainToCmdQueue hook got installed
+        //      (s_streamline.setup) -- means sl.dlss_g.dll loaded and is
+        //      actively interposing. Set before init_d3d12() runs.
+        //   2. sl.dlss_g.dll / sl.interposer.dll present as a backstop.
+        //   3. amd_fidelityfx_framegeneration_dx12.dll present for FSR3 FG.
+        //   4. libxess_fg.dll present for Intel XeSS Frame Generation.
+        if (s_streamline.setup) {
+            return true;
+        }
+        if (GetModuleHandleW(L"sl.dlss_g.dll") != nullptr) {
+            return true;
+        }
+        if (GetModuleHandleW(L"sl.interposer.dll") != nullptr) {
+            return true;
+        }
+        if (GetModuleHandleW(L"amd_fidelityfx_framegeneration_dx12.dll") != nullptr) {
+            return true;
+        }
+        if (GetModuleHandleW(L"libxess_fg.dll") != nullptr) {
+            return true;
+        }
+
+        return false;
     }
 
     void ignore_next_present() {

--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -1062,7 +1062,27 @@ void REFramework::on_frame_d3d12() {
         return;
     }
 
-    cmd_ctx->wait(INFINITE);
+    // On frame-generation swapchains (DLSS-G/FSR3 FG), the Streamline/FSR
+    // interposer holds extra in-flight frames internally for interpolation,
+    // which can leave our ring-buffer's per-context fence unsignalled when we
+    // reach this point. Blocking the Present thread here (wait(INFINITE))
+    // directly jitters the game's Present interval, which FG uses as its
+    // pacing signal -- producing the "micro-stutter with FG on" reports. When
+    // the fence isn't ready, we'd rather skip our overlay for this one frame
+    // (imperceptible at 100+ FPS) than stall Streamline's capture.
+    if (m_d3d12_hook->is_framegen_swapchain()) {
+        if (!cmd_ctx->try_wait(0)) {
+            // GPU still has this context's previous submission in flight.
+            // Skip overlay rendering this frame; we'll pick it up next rotation.
+            if (is_init_ok) {
+                m_mods->on_post_frame();
+            }
+            return;
+        }
+    } else {
+        cmd_ctx->wait(INFINITE);
+    }
+
     {
         std::scoped_lock _{ cmd_ctx->mtx };
         cmd_ctx->has_commands = true;
@@ -2341,7 +2361,16 @@ bool REFramework::init_d3d12() {
 
     m_d3d12.cmd_ctxs.clear();
 
-    for (auto i = 0; i < 3; ++i) {
+    // Frame-generation swapchains (DLSS-G / FSR3 FG) extend the render
+    // pipeline with extra in-flight frames for the interpolation pass. A
+    // 3-deep ring buffer means our per-context fence from "3 game-frames ago"
+    // is often still pending when the next Present comes in, forcing a CPU
+    // stall on wait() that jitters Present timing. 5 contexts gives enough
+    // headroom for the interpolated + real frame queue in the interposer
+    // plus the game's own pipelining, so the common case becomes lock-free.
+    const int num_cmd_ctxs = m_d3d12_hook->is_framegen_swapchain() ? 5 : 3;
+
+    for (auto i = 0; i < num_cmd_ctxs; ++i) {
         auto& ctx = m_d3d12.cmd_ctxs.emplace_back(std::make_unique<d3d12::CommandContext>());
 
         if (!ctx->setup(L"Framework::m_d3d12.cmd_ctx")) {

--- a/src/mods/vr/d3d12/CommandContext.cpp
+++ b/src/mods/vr/d3d12/CommandContext.cpp
@@ -77,6 +77,46 @@ void CommandContext::wait(uint32_t ms) {
     }
 }
 
+bool CommandContext::try_wait(uint32_t ms) {
+    std::scoped_lock _{this->mtx};
+
+    // Nothing pending - context is already free for reuse.
+    if (!this->fence_event || !this->waiting_for_fence) {
+        return true;
+    }
+
+    // Fast poll of the fence value first so we avoid a kernel transition in
+    // the common (ready) case. If the value on the fence already meets the
+    // expected count, we know WaitForSingleObject will return immediately.
+    if (this->fence && this->fence->GetCompletedValue() < this->fence_value) {
+        if (ms == 0) {
+            // Caller wants a non-blocking poll. GPU isn't done yet -- bail.
+            return false;
+        }
+    }
+
+    const DWORD wait_result = WaitForSingleObject(this->fence_event, ms);
+    if (wait_result != WAIT_OBJECT_0) {
+        // Timed out (or wait failed). Leave waiting_for_fence set so the next
+        // wait()/try_wait() call will pick it up; do NOT reset the allocator
+        // while the GPU may still be reading from it.
+        return false;
+    }
+
+    ResetEvent(this->fence_event);
+    this->waiting_for_fence = false;
+
+    if (FAILED(this->cmd_allocator->Reset())) {
+        spdlog::error("[VR] Failed to reset command allocator for {}", utility::narrow(this->internal_name));
+    }
+
+    if (FAILED(this->cmd_list->Reset(this->cmd_allocator.Get(), nullptr))) {
+        spdlog::error("[VR] Failed to reset command list for {}", utility::narrow(this->internal_name));
+    }
+    this->has_commands = false;
+    return true;
+}
+
 void CommandContext::copy(ID3D12Resource* src, ID3D12Resource* dst, D3D12_RESOURCE_STATES src_state, D3D12_RESOURCE_STATES dst_state) {
     std::scoped_lock _{this->mtx};
 

--- a/src/mods/vr/d3d12/CommandContext.hpp
+++ b/src/mods/vr/d3d12/CommandContext.hpp
@@ -15,6 +15,11 @@ struct CommandContext {
     bool setup(const wchar_t* name = L"CommandContext object");
     void reset();
     void wait(uint32_t ms);
+    // Non-blocking variant: returns true if the fence was already signalled (or
+    // nothing was pending) and the context was reset for reuse. Returns false
+    // if the GPU is still busy on this context's previous submission. Used to
+    // avoid stalling the Present thread on frame-generation swapchains.
+    bool try_wait(uint32_t ms = 0);
     void copy(ID3D12Resource* src, ID3D12Resource* dst, 
         D3D12_RESOURCE_STATES src_state = D3D12_RESOURCE_STATE_PRESENT,
         D3D12_RESOURCE_STATES dst_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);


### PR DESCRIPTION
With Frame Generation enabled, REFramework introduces consistent micro-stutter caused by three interacting issues in the D3D12 Present path:

1. RTTI-based FG swapchain detection can silently fail (seen on Pragmata: "Failed to get type info: unknown exception"), leaving m_using_frame_generation_swapchain false even when sl.dlss_g.dll is loaded and actively wrapping the game's swapchain. All downstream FG handling becomes a no-op.

2. The overlay command-context ring buffer is 3-deep, which is too shallow for the FG-extended pipeline. Streamline/FSR3 hold extra frames internally for interpolation, so the per-context fence from "3 game-frames ago" is often still pending when the next Present arrives.

3. cmd_ctx->wait(INFINITE) on the Present thread then stalls by 1-5ms. Without FG this is invisible; with FG, Present interval IS the pacing signal, and the jitter manifests as visible micro-stutter.

Fix:

- D3D12Hook::is_framegen_swapchain() falls back to checking s_streamline.setup and GetModuleHandleW for sl.dlss_g.dll, sl.interposer.dll, amd_fidelityfx_framegeneration_dx12.dll when the RTTI flag isn't set. The two direct reads of m_using_frame_generation_swapchain in D3D12Hook.cpp (inner-swapchain substitution) are unchanged — that logic requires the RTTI-confirmed vtable layout.

- New CommandContext::try_wait(ms=0) uses GetCompletedValue() as a fast path, returns false on timeout without resetting allocator state.

- on_frame_d3d12 uses try_wait(0) on FG swapchains and skips overlay rendering that frame if the fence isn't ready. on_post_frame() still fires; on_post_present() fires unconditionally from the post-Present callback. A skipped overlay frame at 100+ FPS is imperceptible; a stalled Present is not.

- init_d3d12 uses a 5-deep ring buffer on FG swapchains to give enough headroom that try_wait(0) almost never fails.

Non-FG games are unaffected: is_framegen_swapchain() returns false unless one of the FG modules is loaded, preserving the original wait(INFINITE) + 3-context path.

Tested on Pragmata + DLSS-G + path tracing (RTX 5080). FSR3 and XeSS-FG paths are symmetrical but not verified on live hardware.