### PR TITLE
Console window improvement

### DIFF
--- a/csharp-api/REFrameworkNET/Plugin.cpp
+++ b/csharp-api/REFrameworkNET/Plugin.cpp
@@ -21,8 +21,20 @@ using namespace System;
 using namespace System::Runtime;
 
 extern "C" __declspec(dllexport) bool reframework_plugin_initialize(const REFrameworkPluginInitializeParam* param) {
+    HWND prev = GetForegroundWindow();
+
     // Create a console
     AllocConsole();
+
+    HWND console = GetConsoleWindow();
+
+    ShowWindow(console, SW_HIDE);
+    ShowWindow(console, SW_SHOWNOACTIVATE);
+
+    if (prev)
+    {
+        SetForegroundWindow(prev);
+    }
 
     return REFrameworkNET::PluginManager::Entry(param);
 }

--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -9,6 +9,9 @@
 #include <Dbt.h>
 
 #include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/dist_sink.h>
+#include <spdlog/sinks/wincolor_sink.h>
+#include <spdlog/sinks/msvc_sink.h>
 
 // minhook, used for AllocateBuffer
 extern "C" {
@@ -255,6 +258,9 @@ REFramework::REFramework(HMODULE reframework_module)
     {
 
     s_reframework_module = reframework_module;
+    m_dist_sink = std::make_shared<spdlog::sinks::dist_sink_mt>();
+
+    m_logger->sinks().push_back(m_dist_sink);
 
     std::scoped_lock __{m_startup_mutex};
     const auto& gi = sdk::GameIdentity::get();
@@ -2535,4 +2541,22 @@ void REFramework::deinit_d3d12() {
 
     ImGui::GetIO().BackendRendererUserData = nullptr;
     m_d3d12 = {};
+}
+
+void REFramework::open_console() {
+    if (m_console_setup) {
+        SetForegroundWindow(GetConsoleWindow());
+        return;
+    }
+
+    AllocConsole();
+
+    std::shared_ptr<spdlog::sinks::dist_sink_mt> dist_sink = std::static_pointer_cast<spdlog::sinks::dist_sink_mt>(m_dist_sink);
+    dist_sink->add_sink(std::make_shared<spdlog::sinks::wincolor_stdout_sink_st>());
+    dist_sink->add_sink(std::make_shared<spdlog::sinks::wincolor_stderr_sink_st>());
+    dist_sink->add_sink(std::make_shared<spdlog::sinks::msvc_sink_mt>());
+
+    SetForegroundWindow(GetConsoleWindow());
+
+    m_console_setup = true;
 }

--- a/src/REFramework.hpp
+++ b/src/REFramework.hpp
@@ -160,7 +160,7 @@ public:
     }
 
 private:
-        void save_config();
+    void save_config();
     void consume_input();
     void init_fonts();
     void invalidate_device_objects();
@@ -171,6 +171,7 @@ private:
 public:
     bool hook_d3d11();
     bool hook_d3d12();
+    void open_console();
 
 private:
     bool initialize();
@@ -239,6 +240,7 @@ private:
     std::unique_ptr<WindowsMessageHook> m_windows_message_hook;
     std::unique_ptr<DInputHook> m_dinput_hook;
     std::shared_ptr<spdlog::logger> m_logger;
+    spdlog::sink_ptr m_dist_sink;
     Patch::Ptr m_set_cursor_pos_patch{};
 
     std::string m_error{""};
@@ -259,6 +261,7 @@ private:
 
     bool m_sent_message{false};
     bool m_message_hook_requested{false};
+    bool m_console_setup{false};
 
     RendererType m_renderer_type{RendererType::D3D11};
 

--- a/src/mods/ScriptRunner.cpp
+++ b/src/mods/ScriptRunner.cpp
@@ -49,8 +49,6 @@ void error(const char* str) {
 }
 
 void debug(const char* str) {
-    OutputDebugString(str);
-    fprintf(stderr, "%s\n", str);
     spdlog::debug(str);
 }
 }
@@ -956,6 +954,18 @@ void ScriptRunner::hook_battle_rule() {
 }
 
 void ScriptRunner::on_frame() {
+    if (!m_console_startup_checked) {
+        // Delay because C# API hides it
+        if (m_console_startup_delay_frames > 0) {
+            m_console_startup_delay_frames--;
+        } else {
+            m_console_startup_checked = true;
+
+            if (m_open_debug_console_at_startup->value()) {
+                g_framework->open_console();
+            }
+        }
+    }
     if (!m_scene_okay) try {
         if (!m_checked_scene_once) {
             m_checked_scene_once = true;
@@ -1088,15 +1098,13 @@ void ScriptRunner::on_draw_ui() {
         ImGui::SameLine();
 
         if (ImGui::Button("Spawn Debug Console")) {
-            if (!m_console_spawned) {
-                AllocConsole();
-                freopen("CONIN$", "r", stdin);
-                freopen("CONOUT$", "w", stdout);
-                freopen("CONOUT$", "w", stderr);
-
-                m_console_spawned = true;
-            }
+            g_framework->open_console();
         }
+
+        if (m_open_debug_console_at_startup->draw("Open Debug Console at Startup")) {
+            g_framework->request_save_config();
+        }
+
         //Garbage collection currently only showing from main lua state, might rework to show total later?
         if (ImGui::TreeNode("Garbage Collection Stats")) {
             std::scoped_lock _{ m_access_mutex };
@@ -1284,11 +1292,7 @@ void ScriptRunner::on_gui_draw_element(REComponent* gui_element, void* primitive
 }
 
 void ScriptRunner::spew_error(const std::string& p) {
-    OutputDebugString(p.c_str());
-
-    if (m_console_spawned) {
-        fprintf(stderr, "%s\n", p.c_str());
-    }
+    fprintf(stderr, "%s\n", p.c_str());
 
     if (m_log_to_disk->value()) {
         spdlog::error(p);

--- a/src/mods/ScriptRunner.hpp
+++ b/src/mods/ScriptRunner.hpp
@@ -426,10 +426,11 @@ private:
     bool m_checked_scene_once{false};
     bool m_scene_okay{false};
     bool m_has_any_transform_updates{false};
-    bool m_console_spawned{false};
     bool m_needs_first_reset{true};
     bool m_last_online_match_state{false};
     bool m_attempted_hook_battle_rule{false};
+    bool m_console_startup_checked{false};
+    int m_console_startup_delay_frames{2};
     std::optional<uint8_t> m_last_battle_type{};
     const ModToggle::Ptr m_log_to_disk{ ModToggle::create(generate_name("LogToDisk"), false) };
 
@@ -470,6 +471,8 @@ private:
         ModSlider::create(generate_name("GarbageCollectionMajorMultiplier"), 1.0f, 1000.0f, 100.0f)
     };
 
+    const ModToggle::Ptr m_open_debug_console_at_startup{ ModToggle::create(generate_name("OpenDebugConsoleAtStartup"), false) };
+
     ValueList m_options{
         *m_log_to_disk,
         *m_gc_handler,
@@ -477,7 +480,8 @@ private:
         *m_gc_mode,
         *m_gc_budget,
         *m_gc_minor_multiplier,
-        *m_gc_major_multiplier
+        *m_gc_major_multiplier,
+        *m_open_debug_console_at_startup
     };
 
     // Resets the ScriptState and runs autorun scripts again.


### PR DESCRIPTION
Fix #1656, Partly fix #1688 

- Dont let C# console steal focus 
- "Spawn Debug Console" option from Script Runner can now re-focus the console window
- Add option to spawn debug console at startup (for #1688 )
- Make debug console log all stuffs from Lua (not just debug, but also info and error), by using existing sinks from spdlog
    * Console logging sinks are only added when "Spawn Debug Console" is pressed/spawned at startup

