### PR TITLE
Fix for LooseFileLoader being stuck to true in config

### DIFF
--- a/src/mods/LooseTextureLoader.hpp
+++ b/src/mods/LooseTextureLoader.hpp
@@ -60,7 +60,7 @@ public:
     void early_initialize();
 
 private:
-    static constexpr const char* CONFIG_PREFIX = "LooseFileLoader_";
+    static constexpr const char* CONFIG_PREFIX = "LooseTextureLoader_";
     static std::string generate_name(std::string_view name) { return std::string{CONFIG_PREFIX} + name.data(); }
 
     static constexpr const wchar_t *DEFAULT_ROOT_RESOURCE_PATH = L"natives/STM/";


### PR DESCRIPTION
LooseTextureLoader and LooseFileLoader were both using the same config entry. I'm assuming this was a mistake? Right now LooseFileLoader is always being reset back to true because the LooseTextureLoader setting would overwrite it.

This PR gives LooseTextureLoader a unique config entry.