### PR TITLE
CI: Pin cmake to 3.31.4 to fix windows-latest breakage

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -16,6 +16,10 @@ jobs:
           pip install libclang
           python dev/audit_direct_access_clang.py
 
+      - name: Pin cmake
+        run: choco install cmake --version=3.31.4 --installargs 'ADD_CMAKE_TO_PATH=System' -y --no-progress
+        shell: powershell
+
       - name: Configure CMake
         run: cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DDEVELOPER_MODE=ON "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -14,8 +14,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
+      - name: Pin cmake
+        run: choco install cmake --version=3.31.4 --installargs 'ADD_CMAKE_TO_PATH=System' -y --no-progress
+        shell: powershell
+
       - name: Configure CMake
-        run: cmake -S ${{github.workspace}}/csharp-api -B ${{github.workspace}}/csharp-api/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        run: cmake -S ${{github.workspace}}/csharp-api -B ${{github.workspace}}/csharp-api/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
       - name: Build
         run: cmake --build ${{github.workspace}}/csharp-api/build --config ${{env.BUILD_TYPE}} --target ALL_BUILD
@@ -52,6 +56,10 @@ jobs:
         run: |
           pip install libclang
           python dev/audit_direct_access_clang.py
+
+      - name: Pin cmake
+        run: choco install cmake --version=3.31.4 --installargs 'ADD_CMAKE_TO_PATH=System' -y --no-progress
+        shell: powershell
 
       - name: Configure CMake
         run: cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DDEVELOPER_MODE=ON "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"


### PR DESCRIPTION
The GitHub Actions windows-latest runner recently updated to cmake 4.x, which has breaking changes incompatible with the cmkr bootstrap and cmake_minimum_required version handling used in this project. Pins cmake to 3.31.4 via Chocolatey in all build jobs and adds -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to configure steps where missing.
