### PR TITLE
Fix RSZ deserializer offset for shifted REType layouts

### DIFF
--- a/shared/sdk/RETypeCLR.hpp
+++ b/shared/sdk/RETypeCLR.hpp
@@ -157,6 +157,20 @@ public:
 };
 
 struct RETypeCLR : public ::REType {
+    sdk::NativeArray<sdk::DeserializeSequence>& get_deserializers() {
+        return *reinterpret_cast<sdk::NativeArray<sdk::DeserializeSequence>*>(
+            reinterpret_cast<uintptr_t>(this) + ::REType::runtime_size()
+        );
+    }
+
+    const sdk::NativeArray<sdk::DeserializeSequence>& get_deserializers() const {
+        return *reinterpret_cast<const sdk::NativeArray<sdk::DeserializeSequence>*>(
+            reinterpret_cast<uintptr_t>(this) + ::REType::runtime_size()
+        );
+    }
+
+    // Direct member access is only valid for the non-shifted REType layout.
+    // Use get_deserializers() so MHWILDS/RE9 read after the runtime REType size.
     sdk::NativeArray<sdk::DeserializeSequence> deserializers;
 
 #if TDB_VER > 49

--- a/src/mods/tools/ObjectExplorer.cpp
+++ b/src/mods/tools/ObjectExplorer.cpp
@@ -1364,7 +1364,7 @@ void ObjectExplorer::generate_sdk(const bool skip_sdkgenny) {
         }
 
         auto clr_t = (sdk::RETypeCLR*)type_info;
-        auto& deserialize_list = clr_t->deserializers;
+        auto& deserialize_list = clr_t->get_deserializers();
 
         for (const auto& sequence : deserialize_list) {
             const auto code = sequence.get_code();


### PR DESCRIPTION
Since the REF merge in v2, there seems to have been an issue with the handling of `RETypeCLR`, which prevents the v2 REF from correctly exporting RSZ structures from MHWS. I tested 01388 and 01375, and both have this issue. Version 01366, the last version before the v2 merge, can still export `il2cpp_dump.json` from MHWS correctly.

I think the problem is that `RETypeCLR` does not correctly read the runtime-dispatch layouts. For PRAGMATA or MHST3, the `RETypeCLR` structure is as follows:

```c++
// PRAGMATA
class RETypeCLR : public REType
{
public:
	class ArrayDeserializeSequence deserializeThing; //0x0060
	class REType *nativeType; //0x0070
	char *name2; //0x0078
}; //Size: 0x0080
static_assert(sizeof(RETypeCLR) == 0x80);

// MHST3
class RETypeCLR : public REType
{
public:
	class ArrayDeserializeSequence deserializeThing; //0x0060
	class REType *nativeType; //0x0070
	char *name2; //0x0078
}; //Size: 0x0080
static_assert(sizeof(RETypeCLR) == 0x80);
```

However, MHWS has an additional `0x0008` offset, and its layout is as follows:

```c++
// MHWS
class RETypeCLR : public REType
{
public:
	class ArrayDeserializeSequence deserializeThing; //0x0068
	class REType *nativeType; //0x0078
	char *name2; //0x0080
}; //Size: 0x0088
static_assert(sizeof(RETypeCLR) == 0x88);
```

Although `REType` can already automatically read the layout for different games through runtime-dispatch layouts, `RETypeCLR` does not perform this kind of handling. Instead, it uses the default `REType`, which causes MHWS to use the default `0x0060` offset instead of the correct `0x0068` offset. As a result, the RSZ properties are missing entirely from the exported `il2cpp_dump.json`, which then prevents the RSZ template from being generated correctly.

In this PR, I made a simple change so that `RETypeCLR` can also read each game's own layout instead of loading the default layout. I tested this in MHWS, MHST3, and PRAGMATA. After this change, all of these games can correctly export the corresponding `il2cpp_dump.json`.