### PR TITLE
Fix config being saved every frame while the Configuration header is expanded

### DIFF
--- a/src/Mod.hpp
+++ b/src/Mod.hpp
@@ -331,6 +331,8 @@ public:
             return false;
         }
 
+        bool changed = false;
+
         ImGui::PushID(this);
         ImGui::Button(name.data());
 
@@ -346,7 +348,9 @@ public:
                 }
 
                 if (keys[k]) {
-                    m_value = is_erase_key(k) ? UNBOUND_KEY : k;
+                    const auto new_value = is_erase_key(k) ? UNBOUND_KEY : k;
+                    changed = new_value != m_value;
+                    m_value = new_value;
                     m_waiting_for_new_key = false;
                     break;
                 }
@@ -368,7 +372,7 @@ public:
 
         ImGui::PopID();
 
-        return true;
+        return changed;
     }
 
     bool is_key_down() const {


### PR DESCRIPTION
### Problem

With the REFramework menu open and the **Configuration** header expanded, `re2_fw_config.txt` is rewritten every frame (twice per frame in practice — once per imgui pass, from two threads). In an ~80 minute Dragon's Dogma 2 session this produced **144,370** `Saving config` entries: ~74% of a 439k-line, 37 MB `re2_framework_log.txt`. Each one also walks the whole `Mod::on_config_save` chain, so every Lua script's `re.on_config_save` callback and every plugin's runs at frame rate too.

### Cause

`ModKey::draw()` ends with an unconditional `return true;` (fa23b2ae, 2019). That was harmless while every caller discarded the result. c27a060b (#1529, Feb 2026) started reading it:

```cpp
changed |= m_menu_key->draw("Menu Key");
changed |= m_show_cursor_key->draw("Show Cursor Key");
...
if (changed) {
    g_framework->request_save_config();
}
```

so `changed` is true on every frame that section is drawn, and `request_save_config()` fires every frame.

### Fix

Return whether the binding actually changed. `REFrameworkConfig::on_draw_ui` is the only place that reads a `ModKey::draw()` return value — FirstPerson, FreeCam, Graphics, ManualFlashlight, Scene and VR all discard it — so nothing else changes behaviour.

### Repro

1. Open the menu, expand **Configuration**, leave the menu open.
2. Tail `re2_framework_log.txt`: a `Saving config` / `Saved config` pair per imgui pass, indefinitely.

### Testing

Reproduced on a nightly build (a0e9010, v1.5.9.1+487) on DD2. I don't have MSVC on this machine, so the change isn't compiled locally; it is types-only (`int32_t` throughout, `UNBOUND_KEY` is `constexpr int32_t`) and CI covers the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
