### PR TITLE
Display Size and REF UI handling changes/fixes | Remember mod UI dropdown status (lua/.NET)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1404,6 +1404,21 @@ endif()
 # Target: REFramework
 if(REF_BUILD_FRAMEWORK AND CMAKE_SIZEOF_VOID_P EQUAL 8) # build-framework
 	set(CMKR_TARGET REFramework)
+	set_source_files_properties(
+	    "src/cimgui/cimgui.cpp"
+	    PROPERTIES COMPILE_DEFINITIONS
+	        "igTreeNode_Str=igTreeNode_Str_cimgui_generated;
+	         igTreeNode_StrStr=igTreeNode_StrStr_cimgui_generated;
+	         igTreeNode_StrStr0=igTreeNode_StrStr0_cimgui_generated;
+	         igTreeNodeV_Str=igTreeNodeV_Str_cimgui_generated;
+	         igTreeNodeEx_Str=igTreeNodeEx_Str_cimgui_generated;
+	         igTreeNodeEx_StrStr=igTreeNodeEx_StrStr_cimgui_generated;
+	         igTreeNodeEx_StrStr0=igTreeNodeEx_StrStr0_cimgui_generated;
+	         igTreeNodeExV_Str=igTreeNodeExV_Str_cimgui_generated;
+	         igCollapsingHeader_TreeNodeFlags=igCollapsingHeader_TreeNodeFlags_cimgui_generated;
+	         igCollapsingHeader_BoolPtr=igCollapsingHeader_BoolPtr_cimgui_generated"
+	)
+
 	set(REFramework_SOURCES
 		cmake.toml
 		"src/D3D11Hook.cpp"
@@ -1433,6 +1448,7 @@ if(REF_BUILD_FRAMEWORK AND CMAKE_SIZEOF_VOID_P EQUAL 8) # build-framework
 		"src/WindowsMessageHook.hpp"
 		"src/cimgui/cimgui.cpp"
 		"src/cimgui/cimgui.h"
+		"src/cimgui/cimgui_ref.cpp"
 		"src/mods/APIProxy.cpp"
 		"src/mods/APIProxy.hpp"
 		"src/mods/BackBufferRenderer.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1519,6 +1519,7 @@ if(REF_BUILD_FRAMEWORK AND CMAKE_SIZEOF_VOID_P EQUAL 8) # build-framework
 		"src/re2-imgui/re2_imconfig.hpp"
 		"src/utility/ImGui.cpp"
 		"src/utility/ImGui.hpp"
+		"src/utility/PersistentTreeState.hpp"
 	)
 
 	add_library(REFramework SHARED)

--- a/cmake.toml
+++ b/cmake.toml
@@ -246,6 +246,20 @@ link-libraries = [
     "DirectXTK12"
 ]
 cmake-before="""
+set_source_files_properties(
+    "src/cimgui/cimgui.cpp"
+    PROPERTIES COMPILE_DEFINITIONS
+        "igTreeNode_Str=igTreeNode_Str_cimgui_generated;
+         igTreeNode_StrStr=igTreeNode_StrStr_cimgui_generated;
+         igTreeNode_StrStr0=igTreeNode_StrStr0_cimgui_generated;
+         igTreeNodeV_Str=igTreeNodeV_Str_cimgui_generated;
+         igTreeNodeEx_Str=igTreeNodeEx_Str_cimgui_generated;
+         igTreeNodeEx_StrStr=igTreeNodeEx_StrStr_cimgui_generated;
+         igTreeNodeEx_StrStr0=igTreeNodeEx_StrStr0_cimgui_generated;
+         igTreeNodeExV_Str=igTreeNodeExV_Str_cimgui_generated;
+         igCollapsingHeader_TreeNodeFlags=igCollapsingHeader_TreeNodeFlags_cimgui_generated;
+         igCollapsingHeader_BoolPtr=igCollapsingHeader_BoolPtr_cimgui_generated"
+)
 """
 cmake-after="""
 add_custom_command(

--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -1696,10 +1696,6 @@ void REFramework::preserve_main_window_position(const char* window_name) {
             position = ImVec2{position.x * display_scale.x, position.y * display_scale.y};
             window_size = ImVec2{window_size.x * display_scale.x, window_size.y * display_scale.y};
             m_font_size *= display_scale.y;
-            REFrameworkConfig::get()->set_ui_layout_state(
-                static_cast<int32_t>(m_main_window_monitor_size.x),
-                static_cast<int32_t>(m_main_window_monitor_size.y),
-                m_font_size);
             restoring_scaled_size = true;
         }
     } else if (const auto* settings = ImGui::FindWindowSettingsByID(ImHashStr(window_name)); settings != nullptr) {
@@ -1753,6 +1749,12 @@ void REFramework::preserve_main_window_position(const char* window_name) {
 
     if (restoring_scaled_size) {
         ImGui::SetNextWindowSize(window_size, ImGuiCond_Always);
+        REFrameworkConfig::get()->set_ui_layout_state(
+            static_cast<int32_t>(m_main_window_monitor_size.x),
+            static_cast<int32_t>(m_main_window_monitor_size.y),
+            m_font_size);
+        request_save_config();
+        m_wants_save_imgui_config = true;
     }
 }
 

--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -19,6 +19,7 @@ extern "C" {
 };
 
 #include <imgui.h>
+#include <imgui_internal.h>
 #include <imgui_freetype.h>
 #include <ImGuizmo.h>
 #include <imnodes.h>
@@ -855,6 +856,13 @@ void REFramework::run_imgui_frame(bool from_present) {
     draw_ui();
     m_last_draw_ui = m_draw_ui;
 
+    if (m_wants_save_imgui_config.exchange(false)) {
+        if (const auto* ini_filename = ImGui::GetIO().IniFilename; ini_filename != nullptr) {
+            ImGui::SaveIniSettingsToDisk(ini_filename);
+            spdlog::info("Saved ImGui configuration");
+        }
+    }
+
     IMGUIZMO_NAMESPACE::BeginFrame();
 
     ImGui::EndFrame();
@@ -1474,9 +1482,38 @@ void REFramework::set_draw_ui(bool state, bool should_save) {
         REFrameworkConfig::get()->get_menu_open()->value() = state;
     }
 
-    if (state != prev_state && should_save && m_game_data_initialized) {
-        save_config();
+    if (state != prev_state && should_save) {
+        if (!state) {
+            if (m_main_window_monitor_size.x > 0.0f && m_main_window_monitor_size.y > 0.0f) {
+                REFrameworkConfig::get()->set_ui_layout_state(
+                    static_cast<int32_t>(m_main_window_monitor_size.x),
+                    static_cast<int32_t>(m_main_window_monitor_size.y),
+                    m_font_size);
+            }
+
+            m_wants_save_imgui_config = true;
+        }
+
+        if (m_game_data_initialized) {
+            save_config();
+        }
     }
+}
+
+void REFramework::set_font_size_for_display(float size, float source_monitor_height) {
+    float current_monitor_height = 0.0f;
+    const auto monitor = MonitorFromWindow(m_wnd, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO monitor_info{sizeof(MONITORINFO)};
+
+    if (monitor != nullptr && GetMonitorInfo(monitor, &monitor_info)) {
+        current_monitor_height = static_cast<float>(monitor_info.rcMonitor.bottom - monitor_info.rcMonitor.top);
+    }
+
+    if (source_monitor_height > 0.0f && current_monitor_height > 0.0f) {
+        size *= current_monitor_height / source_monitor_height;
+    }
+
+    set_font_size(size);
 }
 
 void REFramework::consume_input() {
@@ -1622,6 +1659,102 @@ void REFramework::invalidate_device_objects() {
     m_wants_device_object_cleanup = false;
 }
 
+void REFramework::preserve_main_window_position(const char* window_name) {
+    const auto monitor = MonitorFromWindow(m_wnd, MONITOR_DEFAULTTONEAREST);
+    const auto previous_monitor_size = m_main_window_monitor_size;
+    MONITORINFO monitor_info{sizeof(MONITORINFO)};
+
+    if (monitor != nullptr && GetMonitorInfo(monitor, &monitor_info)) {
+        m_main_window_monitor = monitor;
+        m_main_window_monitor_size = ImVec2{
+            static_cast<float>(monitor_info.rcMonitor.right - monitor_info.rcMonitor.left),
+            static_cast<float>(monitor_info.rcMonitor.bottom - monitor_info.rcMonitor.top)};
+    } else if (monitor != m_main_window_monitor) {
+        m_main_window_monitor = monitor;
+        m_main_window_monitor_size = {};
+    }
+
+    const bool monitor_size_changed =
+        previous_monitor_size.x > 0.0f && previous_monitor_size.y > 0.0f &&
+        m_main_window_monitor_size.x > 0.0f && m_main_window_monitor_size.y > 0.0f &&
+        (previous_monitor_size.x != m_main_window_monitor_size.x ||
+         previous_monitor_size.y != m_main_window_monitor_size.y);
+
+    ImVec2 position{};
+    ImVec2 window_size{};
+    bool restoring_scaled_size = false;
+
+    if (const auto* window = ImGui::FindWindowByName(window_name); window != nullptr) {
+        position = window->Pos;
+        window_size = window->Size;
+
+        if (monitor_size_changed) {
+            const ImVec2 display_scale{
+                m_main_window_monitor_size.x / previous_monitor_size.x,
+                m_main_window_monitor_size.y / previous_monitor_size.y};
+            position = ImVec2{position.x * display_scale.x, position.y * display_scale.y};
+            window_size = ImVec2{window_size.x * display_scale.x, window_size.y * display_scale.y};
+            m_font_size *= display_scale.y;
+            REFrameworkConfig::get()->set_ui_layout_state(
+                static_cast<int32_t>(m_main_window_monitor_size.x),
+                static_cast<int32_t>(m_main_window_monitor_size.y),
+                m_font_size);
+            restoring_scaled_size = true;
+        }
+    } else if (const auto* settings = ImGui::FindWindowSettingsByID(ImHashStr(window_name)); settings != nullptr) {
+        position = ImVec2{static_cast<float>(settings->Pos.x), static_cast<float>(settings->Pos.y)};
+        window_size = ImVec2{static_cast<float>(settings->Size.x), static_cast<float>(settings->Size.y)};
+
+        if (!m_loaded_saved_ui_monitor_size) {
+            m_loaded_saved_ui_monitor_size = true;
+            const auto config_path = get_persistent_dir(REFrameworkConfig::REFRAMEWORK_CONFIG_NAME.data()).string();
+
+            if (fs::exists(utility::widen(config_path))) {
+                const utility::Config cfg{config_path};
+                m_saved_ui_monitor_size = ImVec2{
+                    static_cast<float>(cfg.get<int32_t>(REFrameworkConfig::UI_MONITOR_WIDTH_CONFIG_NAME.data()).value_or(0)),
+                    static_cast<float>(cfg.get<int32_t>(REFrameworkConfig::UI_MONITOR_HEIGHT_CONFIG_NAME.data()).value_or(0))};
+            }
+        }
+
+        if (m_saved_ui_monitor_size.x > 0.0f && m_saved_ui_monitor_size.y > 0.0f &&
+            m_main_window_monitor_size.x > 0.0f && m_main_window_monitor_size.y > 0.0f &&
+            (m_saved_ui_monitor_size.x != m_main_window_monitor_size.x ||
+             m_saved_ui_monitor_size.y != m_main_window_monitor_size.y)) {
+            const ImVec2 display_scale{
+                m_main_window_monitor_size.x / m_saved_ui_monitor_size.x,
+                m_main_window_monitor_size.y / m_saved_ui_monitor_size.y};
+            position = ImVec2{position.x * display_scale.x, position.y * display_scale.y};
+            window_size = ImVec2{window_size.x * display_scale.x, window_size.y * display_scale.y};
+            restoring_scaled_size = true;
+        }
+    } else {
+        return;
+    }
+
+    if (m_main_window_monitor_size.x > 0.0f && m_main_window_monitor_size.y > 0.0f) {
+        const auto visibility_padding = ImMax(ImGui::GetStyle().DisplayWindowPadding, ImGui::GetStyle().DisplaySafeAreaPadding);
+
+        if (position.x > m_main_window_monitor_size.x - visibility_padding.x) {
+            position.x = ImMax(0.0f, m_main_window_monitor_size.x - window_size.x);
+        } else if (position.x + window_size.x < visibility_padding.x) {
+            position.x = 0.0f;
+        }
+
+        if (position.y > m_main_window_monitor_size.y - visibility_padding.y) {
+            position.y = ImMax(0.0f, m_main_window_monitor_size.y - window_size.y);
+        } else if (position.y + window_size.y < visibility_padding.y) {
+            position.y = 0.0f;
+        }
+    }
+
+    ImGui::SetNextWindowPos(position, ImGuiCond_Always);
+
+    if (restoring_scaled_size) {
+        ImGui::SetNextWindowSize(window_size, ImGuiCond_Always);
+    }
+}
+
 void REFramework::draw_ui() {
     std::lock_guard _{m_input_mutex};
 
@@ -1680,6 +1813,7 @@ void REFramework::draw_ui() {
 
     ImGui::PushFont(m_default_font, m_font_size);
     static const auto REF_NAME = std::format("REFramework [{}+{}-{:.8}]", REF_TAG, REF_COMMITS_PAST_TAG, REF_COMMIT_HASH);
+    preserve_main_window_position(REF_NAME.c_str());
     bool is_open = true;
     ImGui::Begin(REF_NAME.c_str(), &is_open);
     ImGui::Text("Default Menu Key: Insert");
@@ -1954,6 +2088,8 @@ bool REFramework::initialize() {
 
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
+        m_loaded_saved_ui_monitor_size = false;
+        m_main_window_monitor = nullptr;
         ImNodes::SetImGuiContext(ImGui::GetCurrentContext());
         ImNodes::CreateContext();
 
@@ -2017,6 +2153,8 @@ bool REFramework::initialize() {
 
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
+        m_loaded_saved_ui_monitor_size = false;
+        m_main_window_monitor = nullptr;
         ImNodes::SetImGuiContext(ImGui::GetCurrentContext());
         ImNodes::CreateContext();
 

--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -31,6 +31,7 @@ extern "C" {
 
 #include "utility/Module.hpp"
 #include "utility/Patch.hpp"
+#include "utility/PersistentTreeState.hpp"
 #include "utility/Scan.hpp"
 #include "utility/Thread.hpp"
 
@@ -2097,6 +2098,7 @@ bool REFramework::initialize() {
 
         static const auto imgui_ini = (get_persistent_dir() / "ref_ui.ini").string();
         ImGui::GetIO().IniFilename = imgui_ini.c_str();
+        reframework::ui::initialize_tree_state(get_persistent_dir() / "ref_dropdown_status.ini");
 
         spdlog::info("Initializing ImGui Win32");
 
@@ -2162,6 +2164,7 @@ bool REFramework::initialize() {
 
         static const auto imgui_ini = (get_persistent_dir() / "ref_ui.ini").string();
         ImGui::GetIO().IniFilename = imgui_ini.c_str();
+        reframework::ui::initialize_tree_state(get_persistent_dir() / "ref_dropdown_status.ini");
         
         if (!ImGui_ImplWin32_Init(m_wnd)) {
             spdlog::error("Failed to initialize ImGui ImplWin32.");

--- a/src/REFramework.cpp
+++ b/src/REFramework.cpp
@@ -810,6 +810,30 @@ REFramework::~REFramework() {
 
     m_d3d_monitor_thread.reset();
 
+    const bool ui_layout_save_pending = std::exchange(m_ui_layout_save_pending, false);
+    m_wants_save_imgui_config = false;
+    const bool can_save_imgui_config = m_has_frame && ImGui::GetCurrentContext() != nullptr;
+
+    if (ui_layout_save_pending) {
+        if (m_mods_fully_initialized && can_save_imgui_config) {
+            save_config();
+
+            if (const auto* ini_filename = ImGui::GetIO().IniFilename; ini_filename != nullptr) {
+                ImGui::SaveIniSettingsToDisk(ini_filename);
+            }
+        }
+    } else {
+        if (m_wants_save_config && m_mods_fully_initialized) {
+            save_config();
+        }
+
+        if (can_save_imgui_config) {
+            if (const auto* ini_filename = ImGui::GetIO().IniFilename; ini_filename != nullptr) {
+                ImGui::SaveIniSettingsToDisk(ini_filename);
+            }
+        }
+    }
+
     if (m_is_d3d11) {
         deinit_d3d11();
     }
@@ -856,6 +880,9 @@ void REFramework::run_imgui_frame(bool from_present) {
 
     draw_ui();
     m_last_draw_ui = m_draw_ui;
+
+    ensure_ui_layout_baseline();
+    process_ui_layout_save(from_present);
 
     if (m_wants_save_imgui_config.exchange(false)) {
         if (const auto* ini_filename = ImGui::GetIO().IniFilename; ini_filename != nullptr) {
@@ -1485,13 +1512,14 @@ void REFramework::set_draw_ui(bool state, bool should_save) {
 
     if (state != prev_state && should_save) {
         if (!state) {
-            if (m_main_window_monitor_size.x > 0.0f && m_main_window_monitor_size.y > 0.0f) {
+            if (m_main_window_display_size.x > 0.0f && m_main_window_display_size.y > 0.0f) {
                 REFrameworkConfig::get()->set_ui_layout_state(
-                    static_cast<int32_t>(m_main_window_monitor_size.x),
-                    static_cast<int32_t>(m_main_window_monitor_size.y),
+                    static_cast<int32_t>(m_main_window_display_size.x),
+                    static_cast<int32_t>(m_main_window_display_size.y),
                     m_font_size);
             }
 
+            m_ui_layout_save_pending = false;
             m_wants_save_imgui_config = true;
         }
 
@@ -1501,20 +1529,23 @@ void REFramework::set_draw_ui(bool state, bool should_save) {
     }
 }
 
-void REFramework::set_font_size_for_display(float size, float source_monitor_height) {
-    float current_monitor_height = 0.0f;
-    const auto monitor = MonitorFromWindow(m_wnd, MONITOR_DEFAULTTONEAREST);
-    MONITORINFO monitor_info{sizeof(MONITORINFO)};
+void REFramework::set_font_size_for_display(float size, float source_display_height) {
+    float current_display_height = 0.0f;
+    RECT client_rect{};
 
-    if (monitor != nullptr && GetMonitorInfo(monitor, &monitor_info)) {
-        current_monitor_height = static_cast<float>(monitor_info.rcMonitor.bottom - monitor_info.rcMonitor.top);
+    if (m_wnd != nullptr && GetClientRect(m_wnd, &client_rect)) {
+        current_display_height = static_cast<float>(client_rect.bottom - client_rect.top);
     }
 
-    if (source_monitor_height > 0.0f && current_monitor_height > 0.0f) {
-        size *= current_monitor_height / source_monitor_height;
+    if (source_display_height > 0.0f && current_display_height > 0.0f) {
+        size *= current_display_height / source_display_height;
     }
 
     set_font_size(size);
+
+    if (current_display_height > 0.0f) {
+        m_font_display_height = current_display_height;
+    }
 }
 
 void REFramework::consume_input() {
@@ -1660,67 +1691,161 @@ void REFramework::invalidate_device_objects() {
     m_wants_device_object_cleanup = false;
 }
 
-void REFramework::preserve_main_window_position(const char* window_name) {
-    const auto monitor = MonitorFromWindow(m_wnd, MONITOR_DEFAULTTONEAREST);
-    const auto previous_monitor_size = m_main_window_monitor_size;
-    MONITORINFO monitor_info{sizeof(MONITORINFO)};
-
-    if (monitor != nullptr && GetMonitorInfo(monitor, &monitor_info)) {
-        m_main_window_monitor = monitor;
-        m_main_window_monitor_size = ImVec2{
-            static_cast<float>(monitor_info.rcMonitor.right - monitor_info.rcMonitor.left),
-            static_cast<float>(monitor_info.rcMonitor.bottom - monitor_info.rcMonitor.top)};
-    } else if (monitor != m_main_window_monitor) {
-        m_main_window_monitor = monitor;
-        m_main_window_monitor_size = {};
+void REFramework::ensure_ui_layout_baseline() {
+    if (!m_mods_fully_initialized || REFrameworkConfig::get()->has_ui_layout_state()) {
+        return;
     }
 
-    const bool monitor_size_changed =
-        previous_monitor_size.x > 0.0f && previous_monitor_size.y > 0.0f &&
-        m_main_window_monitor_size.x > 0.0f && m_main_window_monitor_size.y > 0.0f &&
-        (previous_monitor_size.x != m_main_window_monitor_size.x ||
-         previous_monitor_size.y != m_main_window_monitor_size.y);
+    const auto display_size = ImGui::GetIO().DisplaySize;
+
+    if (display_size.x <= 0.0f || display_size.y <= 0.0f) {
+        return;
+    }
+
+    REFrameworkConfig::get()->set_ui_layout_state(
+        static_cast<int32_t>(display_size.x),
+        static_cast<int32_t>(display_size.y),
+        m_font_size);
+    request_save_config();
+}
+
+void REFramework::process_ui_layout_save(bool from_present) {
+    if (!m_ui_layout_save_pending || from_present ||
+        std::chrono::steady_clock::now() - m_ui_layout_last_changed < std::chrono::milliseconds{500}) {
+        return;
+    }
+
+    m_ui_layout_save_pending = false;
+    request_save_config();
+    m_wants_save_imgui_config = true;
+    m_saved_ui_display_size = m_main_window_display_size;
+}
+
+void REFramework::scale_font_for_display(float display_height) {
+    if (display_height <= 0.0f) {
+        return;
+    }
+
+    if (m_font_display_height > 0.0f && m_font_display_height != display_height) {
+        m_font_size *= display_height / m_font_display_height;
+    }
+
+    m_font_display_height = display_height;
+}
+
+void REFramework::track_manual_ui_layout_changes() {
+    auto& context = *ImGui::GetCurrentContext();
+    const bool left_mouse_down = ImGui::IsMouseDown(ImGuiMouseButton_Left);
+    const bool left_mouse_released = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
+
+    for (const auto* window : context.Windows) {
+        if (window->LastFrameActive != context.FrameCount ||
+            (window->Flags & (ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_ChildWindow)) != 0) {
+            continue;
+        }
+
+        const UIWindowGeometry geometry{window->Pos, window->SizeFull};
+        const auto [entry, inserted] = m_ui_window_geometries.try_emplace(window->ID, geometry);
+
+        if (inserted) {
+            continue;
+        }
+
+        const bool geometry_changed =
+            entry->second.position.x != geometry.position.x ||
+            entry->second.position.y != geometry.position.y ||
+            entry->second.size.x != geometry.size.x ||
+            entry->second.size.y != geometry.size.y;
+
+        entry->second = geometry;
+
+        if (geometry_changed && (left_mouse_down || left_mouse_released)) {
+            m_manual_ui_geometry_dirty = true;
+        }
+    }
+
+    if (m_ui_layout_save_pending) {
+        m_manual_ui_geometry_dirty = false;
+    } else if (left_mouse_released && std::exchange(m_manual_ui_geometry_dirty, false)) {
+        m_wants_save_imgui_config = true;
+    }
+}
+
+void REFramework::preserve_main_window_position(const char* window_name) {
+    const auto previous_display_size = m_main_window_display_size;
+    const auto current_display_size = ImGui::GetIO().DisplaySize;
+
+    if (current_display_size.x <= 0.0f || current_display_size.y <= 0.0f) {
+        return;
+    }
+
+    m_main_window_display_size = current_display_size;
+
+    const bool display_size_changed =
+        previous_display_size.x > 0.0f && previous_display_size.y > 0.0f &&
+        (previous_display_size.x != m_main_window_display_size.x ||
+         previous_display_size.y != m_main_window_display_size.y);
+
+    scale_font_for_display(m_main_window_display_size.y);
+
+    if (!m_loaded_saved_ui_display_size) {
+        m_loaded_saved_ui_display_size = true;
+        const auto config_path = get_persistent_dir(REFrameworkConfig::REFRAMEWORK_CONFIG_NAME.data()).string();
+
+        if (fs::exists(utility::widen(config_path))) {
+            const utility::Config cfg{config_path};
+            m_saved_ui_display_size = ImVec2{
+                static_cast<float>(cfg.get<int32_t>(REFrameworkConfig::UI_MONITOR_WIDTH_CONFIG_NAME.data()).value_or(0)),
+                static_cast<float>(cfg.get<int32_t>(REFrameworkConfig::UI_MONITOR_HEIGHT_CONFIG_NAME.data()).value_or(0))};
+        }
+    }
 
     ImVec2 position{};
     ImVec2 window_size{};
     bool restoring_scaled_size = false;
+    bool returned_to_saved_display = false;
 
-    if (const auto* window = ImGui::FindWindowByName(window_name); window != nullptr) {
+    const auto* settings = ImGui::FindWindowSettingsByID(ImHashStr(window_name));
+    const bool current_display_is_saved_display =
+        m_saved_ui_display_size.x > 0.0f && m_saved_ui_display_size.y > 0.0f &&
+        m_saved_ui_display_size.x == m_main_window_display_size.x &&
+        m_saved_ui_display_size.y == m_main_window_display_size.y;
+
+    if (display_size_changed && m_ui_layout_save_pending && current_display_is_saved_display && settings != nullptr) {
+        position = ImVec2{static_cast<float>(settings->Pos.x), static_cast<float>(settings->Pos.y)};
+        window_size = ImVec2{static_cast<float>(settings->Size.x), static_cast<float>(settings->Size.y)};
+        restoring_scaled_size = true;
+        returned_to_saved_display = true;
+        m_ui_layout_save_pending = false;
+    } else if (const auto* window = ImGui::FindWindowByName(window_name); window != nullptr) {
         position = window->Pos;
         window_size = window->Size;
 
-        if (monitor_size_changed) {
+        if (display_size_changed) {
             const ImVec2 display_scale{
-                m_main_window_monitor_size.x / previous_monitor_size.x,
-                m_main_window_monitor_size.y / previous_monitor_size.y};
+                m_main_window_display_size.x / previous_display_size.x,
+                m_main_window_display_size.y / previous_display_size.y};
             position = ImVec2{position.x * display_scale.x, position.y * display_scale.y};
             window_size = ImVec2{window_size.x * display_scale.x, window_size.y * display_scale.y};
-            m_font_size *= display_scale.y;
             restoring_scaled_size = true;
         }
-    } else if (const auto* settings = ImGui::FindWindowSettingsByID(ImHashStr(window_name)); settings != nullptr) {
+    } else if (settings != nullptr) {
         position = ImVec2{static_cast<float>(settings->Pos.x), static_cast<float>(settings->Pos.y)};
         window_size = ImVec2{static_cast<float>(settings->Size.x), static_cast<float>(settings->Size.y)};
 
-        if (!m_loaded_saved_ui_monitor_size) {
-            m_loaded_saved_ui_monitor_size = true;
-            const auto config_path = get_persistent_dir(REFrameworkConfig::REFRAMEWORK_CONFIG_NAME.data()).string();
-
-            if (fs::exists(utility::widen(config_path))) {
-                const utility::Config cfg{config_path};
-                m_saved_ui_monitor_size = ImVec2{
-                    static_cast<float>(cfg.get<int32_t>(REFrameworkConfig::UI_MONITOR_WIDTH_CONFIG_NAME.data()).value_or(0)),
-                    static_cast<float>(cfg.get<int32_t>(REFrameworkConfig::UI_MONITOR_HEIGHT_CONFIG_NAME.data()).value_or(0))};
-            }
-        }
-
-        if (m_saved_ui_monitor_size.x > 0.0f && m_saved_ui_monitor_size.y > 0.0f &&
-            m_main_window_monitor_size.x > 0.0f && m_main_window_monitor_size.y > 0.0f &&
-            (m_saved_ui_monitor_size.x != m_main_window_monitor_size.x ||
-             m_saved_ui_monitor_size.y != m_main_window_monitor_size.y)) {
+        if (display_size_changed && m_last_window_size.x > 0.0f && m_last_window_size.y > 0.0f) {
             const ImVec2 display_scale{
-                m_main_window_monitor_size.x / m_saved_ui_monitor_size.x,
-                m_main_window_monitor_size.y / m_saved_ui_monitor_size.y};
+                m_main_window_display_size.x / previous_display_size.x,
+                m_main_window_display_size.y / previous_display_size.y};
+            position = ImVec2{m_last_window_pos.x * display_scale.x, m_last_window_pos.y * display_scale.y};
+            window_size = ImVec2{m_last_window_size.x * display_scale.x, m_last_window_size.y * display_scale.y};
+            restoring_scaled_size = true;
+        } else if (m_saved_ui_display_size.x > 0.0f && m_saved_ui_display_size.y > 0.0f &&
+            (m_saved_ui_display_size.x != m_main_window_display_size.x ||
+             m_saved_ui_display_size.y != m_main_window_display_size.y)) {
+            const ImVec2 display_scale{
+                m_main_window_display_size.x / m_saved_ui_display_size.x,
+                m_main_window_display_size.y / m_saved_ui_display_size.y};
             position = ImVec2{position.x * display_scale.x, position.y * display_scale.y};
             window_size = ImVec2{window_size.x * display_scale.x, window_size.y * display_scale.y};
             restoring_scaled_size = true;
@@ -1729,17 +1854,17 @@ void REFramework::preserve_main_window_position(const char* window_name) {
         return;
     }
 
-    if (m_main_window_monitor_size.x > 0.0f && m_main_window_monitor_size.y > 0.0f) {
+    if (m_main_window_display_size.x > 0.0f && m_main_window_display_size.y > 0.0f) {
         const auto visibility_padding = ImMax(ImGui::GetStyle().DisplayWindowPadding, ImGui::GetStyle().DisplaySafeAreaPadding);
 
-        if (position.x > m_main_window_monitor_size.x - visibility_padding.x) {
-            position.x = ImMax(0.0f, m_main_window_monitor_size.x - window_size.x);
+        if (position.x > m_main_window_display_size.x - visibility_padding.x) {
+            position.x = ImMax(0.0f, m_main_window_display_size.x - window_size.x);
         } else if (position.x + window_size.x < visibility_padding.x) {
             position.x = 0.0f;
         }
 
-        if (position.y > m_main_window_monitor_size.y - visibility_padding.y) {
-            position.y = ImMax(0.0f, m_main_window_monitor_size.y - window_size.y);
+        if (position.y > m_main_window_display_size.y - visibility_padding.y) {
+            position.y = ImMax(0.0f, m_main_window_display_size.y - window_size.y);
         } else if (position.y + window_size.y < visibility_padding.y) {
             position.y = 0.0f;
         }
@@ -1750,11 +1875,14 @@ void REFramework::preserve_main_window_position(const char* window_name) {
     if (restoring_scaled_size) {
         ImGui::SetNextWindowSize(window_size, ImGuiCond_Always);
         REFrameworkConfig::get()->set_ui_layout_state(
-            static_cast<int32_t>(m_main_window_monitor_size.x),
-            static_cast<int32_t>(m_main_window_monitor_size.y),
+            static_cast<int32_t>(m_main_window_display_size.x),
+            static_cast<int32_t>(m_main_window_display_size.y),
             m_font_size);
-        request_save_config();
-        m_wants_save_imgui_config = true;
+
+        if (!returned_to_saved_display) {
+            m_ui_layout_save_pending = true;
+            m_ui_layout_last_changed = std::chrono::steady_clock::now();
+        }
     }
 }
 
@@ -1819,6 +1947,7 @@ void REFramework::draw_ui() {
     preserve_main_window_position(REF_NAME.c_str());
     bool is_open = true;
     ImGui::Begin(REF_NAME.c_str(), &is_open);
+    const auto* main_window = ImGui::GetCurrentWindow();
     ImGui::Text("Default Menu Key: Insert");
     ImGui::Checkbox("Transparency", &m_ui_option_transparent);
     ImGui::SameLine();
@@ -1843,8 +1972,10 @@ void REFramework::draw_ui() {
         ImGui::TextWrapped("REFramework error: %s", m_error.c_str());
     }
 
-    m_last_window_pos = ImGui::GetWindowPos();
-    m_last_window_size = ImGui::GetWindowSize();
+    m_last_window_pos = main_window->Pos;
+    m_last_window_size = main_window->Size;
+
+    track_manual_ui_layout_changes();
 
     ImGui::PopFont();
     ImGui::End();
@@ -2091,8 +2222,8 @@ bool REFramework::initialize() {
 
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
-        m_loaded_saved_ui_monitor_size = false;
-        m_main_window_monitor = nullptr;
+        m_loaded_saved_ui_display_size = false;
+        m_saved_ui_display_size = {};
         ImNodes::SetImGuiContext(ImGui::GetCurrentContext());
         ImNodes::CreateContext();
 
@@ -2157,8 +2288,8 @@ bool REFramework::initialize() {
 
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
-        m_loaded_saved_ui_monitor_size = false;
-        m_main_window_monitor = nullptr;
+        m_loaded_saved_ui_display_size = false;
+        m_saved_ui_display_size = {};
         ImNodes::SetImGuiContext(ImGui::GetCurrentContext());
         ImNodes::CreateContext();
 

--- a/src/REFramework.hpp
+++ b/src/REFramework.hpp
@@ -127,13 +127,16 @@ public:
         return m_startup_mutex;
     }
 
-    void set_font_size(int size) { 
+    void set_font_size(float size) {
         if (m_font_size != size) {
             m_font_size = size;
         }
     }
 
+    void set_font_size_for_display(float size, float source_monitor_height);
+
     auto get_font_size() const { return m_font_size; }
+    auto get_main_window_monitor_size() const { return m_main_window_monitor_size; }
     auto get_default_font() const { return m_default_font; }
 
     void set_font(std::string path) { 
@@ -167,6 +170,7 @@ private:
 
     void draw_ui();
     void draw_about();
+    void preserve_main_window_position(const char* window_name);
 
 public:
     bool hook_d3d11();
@@ -200,6 +204,7 @@ private:
     bool m_has_frame{false};
     bool m_wants_device_object_cleanup{false};
     bool m_wants_save_config{false};
+    std::atomic<bool> m_wants_save_imgui_config{false};
     bool m_draw_ui{true};
     bool m_last_draw_ui{m_draw_ui};
     bool m_is_ui_focused{false};
@@ -210,6 +215,10 @@ private:
     
     ImVec2 m_last_window_pos{};
     ImVec2 m_last_window_size{};
+    HMONITOR m_main_window_monitor{};
+    ImVec2 m_main_window_monitor_size{};
+    bool m_loaded_saved_ui_monitor_size{false};
+    ImVec2 m_saved_ui_monitor_size{};
 
     struct AdditionalFont {
         std::filesystem::path filepath{};

--- a/src/REFramework.hpp
+++ b/src/REFramework.hpp
@@ -131,12 +131,16 @@ public:
         if (m_font_size != size) {
             m_font_size = size;
         }
+
+        if (ImGui::GetCurrentContext() != nullptr && ImGui::GetIO().DisplaySize.y > 0.0f) {
+            m_font_display_height = ImGui::GetIO().DisplaySize.y;
+        }
     }
 
-    void set_font_size_for_display(float size, float source_monitor_height);
+    void set_font_size_for_display(float size, float source_display_height);
 
     auto get_font_size() const { return m_font_size; }
-    auto get_main_window_monitor_size() const { return m_main_window_monitor_size; }
+    auto get_main_window_display_size() const { return m_main_window_display_size; }
     auto get_default_font() const { return m_default_font; }
 
     void set_font(std::string path) { 
@@ -171,6 +175,10 @@ private:
     void draw_ui();
     void draw_about();
     void preserve_main_window_position(const char* window_name);
+    void scale_font_for_display(float display_height);
+    void track_manual_ui_layout_changes();
+    void ensure_ui_layout_baseline();
+    void process_ui_layout_save(bool from_present);
 
 public:
     bool hook_d3d11();
@@ -215,10 +223,19 @@ private:
     
     ImVec2 m_last_window_pos{};
     ImVec2 m_last_window_size{};
-    HMONITOR m_main_window_monitor{};
-    ImVec2 m_main_window_monitor_size{};
-    bool m_loaded_saved_ui_monitor_size{false};
-    ImVec2 m_saved_ui_monitor_size{};
+    ImVec2 m_main_window_display_size{};
+    bool m_loaded_saved_ui_display_size{false};
+    ImVec2 m_saved_ui_display_size{};
+    bool m_ui_layout_save_pending{false};
+    std::chrono::steady_clock::time_point m_ui_layout_last_changed{};
+
+    struct UIWindowGeometry {
+        ImVec2 position{};
+        ImVec2 size{};
+    };
+
+    std::map<ImGuiID, UIWindowGeometry> m_ui_window_geometries{};
+    bool m_manual_ui_geometry_dirty{false};
 
     struct AdditionalFont {
         std::filesystem::path filepath{};
@@ -229,6 +246,7 @@ private:
     std::string m_default_font_file = "DEFAULT";
     bool m_fonts_need_init{true};
     float m_font_size{16};
+    float m_font_display_height{};
     ImFont* m_default_font;
     std::map<std::string, ImFont*> loaded_fonts{};
     std::vector<AdditionalFont> m_additional_fonts{};

--- a/src/cimgui/cimgui.cpp
+++ b/src/cimgui/cimgui.cpp
@@ -9,7 +9,6 @@
 #endif
 #include <imgui_internal.h>
 #include "cimgui.h"
-#include "utility/PersistentTreeState.hpp"
 
 
 
@@ -925,20 +924,13 @@ CIMGUI_API void igSetColorEditOptions(ImGuiColorEditFlags flags)
 }
 CIMGUI_API bool igTreeNode_Str(const char* label)
 {
-    const auto* id = label != nullptr ? label : "";
-    return reframework::ui::persistent_tree_item(
-        reframework::ui::TreeStateSource::CImGui,
-        id,
-        [label]() { return ImGui::TreeNode(label); });
+    return ImGui::TreeNode(label);
 }
 CIMGUI_API bool igTreeNode_StrStr(const char* str_id,const char* fmt,...)
 {
     va_list args;
     va_start(args, fmt);
-    bool ret = reframework::ui::persistent_tree_item(
-        reframework::ui::TreeStateSource::CImGui,
-        str_id != nullptr ? str_id : "",
-        [&]() { return ImGui::TreeNodeV(str_id,fmt,args); });
+    bool ret = ImGui::TreeNodeV(str_id,fmt,args);
     va_end(args);
     return ret;
 }
@@ -964,10 +956,7 @@ CIMGUI_API bool igTreeNode_Ptr0(const void* ptr_id,const char* fmt)
 #endif
 CIMGUI_API bool igTreeNodeV_Str(const char* str_id,const char* fmt,va_list args)
 {
-    return reframework::ui::persistent_tree_item(
-        reframework::ui::TreeStateSource::CImGui,
-        str_id != nullptr ? str_id : "",
-        [&]() { return ImGui::TreeNodeV(str_id,fmt,args); });
+    return ImGui::TreeNodeV(str_id,fmt,args);
 }
 CIMGUI_API bool igTreeNodeV_Ptr(const void* ptr_id,const char* fmt,va_list args)
 {
@@ -975,23 +964,13 @@ CIMGUI_API bool igTreeNodeV_Ptr(const void* ptr_id,const char* fmt,va_list args)
 }
 CIMGUI_API bool igTreeNodeEx_Str(const char* label,ImGuiTreeNodeFlags flags)
 {
-    const bool can_persist = (flags & ImGuiTreeNodeFlags_Leaf) == 0;
-    return reframework::ui::persistent_tree_item(
-        reframework::ui::TreeStateSource::CImGui,
-        label != nullptr ? label : "",
-        [label, flags]() { return ImGui::TreeNodeEx(label,flags); },
-        can_persist);
+    return ImGui::TreeNodeEx(label,flags);
 }
 CIMGUI_API bool igTreeNodeEx_StrStr(const char* str_id,ImGuiTreeNodeFlags flags,const char* fmt,...)
 {
     va_list args;
     va_start(args, fmt);
-    const bool can_persist = (flags & ImGuiTreeNodeFlags_Leaf) == 0;
-    bool ret = reframework::ui::persistent_tree_item(
-        reframework::ui::TreeStateSource::CImGui,
-        str_id != nullptr ? str_id : "",
-        [&]() { return ImGui::TreeNodeExV(str_id,flags,fmt,args); },
-        can_persist);
+    bool ret = ImGui::TreeNodeExV(str_id,flags,fmt,args);
     va_end(args);
     return ret;
 }
@@ -1017,12 +996,7 @@ CIMGUI_API bool igTreeNodeEx_Ptr0(const void* ptr_id,ImGuiTreeNodeFlags flags,co
 #endif
 CIMGUI_API bool igTreeNodeExV_Str(const char* str_id,ImGuiTreeNodeFlags flags,const char* fmt,va_list args)
 {
-    const bool can_persist = (flags & ImGuiTreeNodeFlags_Leaf) == 0;
-    return reframework::ui::persistent_tree_item(
-        reframework::ui::TreeStateSource::CImGui,
-        str_id != nullptr ? str_id : "",
-        [&]() { return ImGui::TreeNodeExV(str_id,flags,fmt,args); },
-        can_persist);
+    return ImGui::TreeNodeExV(str_id,flags,fmt,args);
 }
 CIMGUI_API bool igTreeNodeExV_Ptr(const void* ptr_id,ImGuiTreeNodeFlags flags,const char* fmt,va_list args)
 {
@@ -1046,19 +1020,11 @@ CIMGUI_API float igGetTreeNodeToLabelSpacing()
 }
 CIMGUI_API bool igCollapsingHeader_TreeNodeFlags(const char* label,ImGuiTreeNodeFlags flags)
 {
-    return reframework::ui::persistent_tree_item(
-        reframework::ui::TreeStateSource::CImGui,
-        label != nullptr ? label : "",
-        [label, flags]() { return ImGui::CollapsingHeader(label,flags); },
-        (flags & ImGuiTreeNodeFlags_Leaf) == 0);
+    return ImGui::CollapsingHeader(label,flags);
 }
 CIMGUI_API bool igCollapsingHeader_BoolPtr(const char* label,bool* p_visible,ImGuiTreeNodeFlags flags)
 {
-    return reframework::ui::persistent_tree_item(
-        reframework::ui::TreeStateSource::CImGui,
-        label != nullptr ? label : "",
-        [label, p_visible, flags]() { return ImGui::CollapsingHeader(label,p_visible,flags); },
-        (flags & ImGuiTreeNodeFlags_Leaf) == 0);
+    return ImGui::CollapsingHeader(label,p_visible,flags);
 }
 CIMGUI_API void igSetNextItemOpen(bool is_open,ImGuiCond cond)
 {

--- a/src/cimgui/cimgui.cpp
+++ b/src/cimgui/cimgui.cpp
@@ -9,6 +9,7 @@
 #endif
 #include <imgui_internal.h>
 #include "cimgui.h"
+#include "utility/PersistentTreeState.hpp"
 
 
 
@@ -924,13 +925,20 @@ CIMGUI_API void igSetColorEditOptions(ImGuiColorEditFlags flags)
 }
 CIMGUI_API bool igTreeNode_Str(const char* label)
 {
-    return ImGui::TreeNode(label);
+    const auto* id = label != nullptr ? label : "";
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        id,
+        [label]() { return ImGui::TreeNode(label); });
 }
 CIMGUI_API bool igTreeNode_StrStr(const char* str_id,const char* fmt,...)
 {
     va_list args;
     va_start(args, fmt);
-    bool ret = ImGui::TreeNodeV(str_id,fmt,args);
+    bool ret = reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        str_id != nullptr ? str_id : "",
+        [&]() { return ImGui::TreeNodeV(str_id,fmt,args); });
     va_end(args);
     return ret;
 }
@@ -956,7 +964,10 @@ CIMGUI_API bool igTreeNode_Ptr0(const void* ptr_id,const char* fmt)
 #endif
 CIMGUI_API bool igTreeNodeV_Str(const char* str_id,const char* fmt,va_list args)
 {
-    return ImGui::TreeNodeV(str_id,fmt,args);
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        str_id != nullptr ? str_id : "",
+        [&]() { return ImGui::TreeNodeV(str_id,fmt,args); });
 }
 CIMGUI_API bool igTreeNodeV_Ptr(const void* ptr_id,const char* fmt,va_list args)
 {
@@ -964,13 +975,23 @@ CIMGUI_API bool igTreeNodeV_Ptr(const void* ptr_id,const char* fmt,va_list args)
 }
 CIMGUI_API bool igTreeNodeEx_Str(const char* label,ImGuiTreeNodeFlags flags)
 {
-    return ImGui::TreeNodeEx(label,flags);
+    const bool can_persist = (flags & ImGuiTreeNodeFlags_Leaf) == 0;
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        label != nullptr ? label : "",
+        [label, flags]() { return ImGui::TreeNodeEx(label,flags); },
+        can_persist);
 }
 CIMGUI_API bool igTreeNodeEx_StrStr(const char* str_id,ImGuiTreeNodeFlags flags,const char* fmt,...)
 {
     va_list args;
     va_start(args, fmt);
-    bool ret = ImGui::TreeNodeExV(str_id,flags,fmt,args);
+    const bool can_persist = (flags & ImGuiTreeNodeFlags_Leaf) == 0;
+    bool ret = reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        str_id != nullptr ? str_id : "",
+        [&]() { return ImGui::TreeNodeExV(str_id,flags,fmt,args); },
+        can_persist);
     va_end(args);
     return ret;
 }
@@ -996,7 +1017,12 @@ CIMGUI_API bool igTreeNodeEx_Ptr0(const void* ptr_id,ImGuiTreeNodeFlags flags,co
 #endif
 CIMGUI_API bool igTreeNodeExV_Str(const char* str_id,ImGuiTreeNodeFlags flags,const char* fmt,va_list args)
 {
-    return ImGui::TreeNodeExV(str_id,flags,fmt,args);
+    const bool can_persist = (flags & ImGuiTreeNodeFlags_Leaf) == 0;
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        str_id != nullptr ? str_id : "",
+        [&]() { return ImGui::TreeNodeExV(str_id,flags,fmt,args); },
+        can_persist);
 }
 CIMGUI_API bool igTreeNodeExV_Ptr(const void* ptr_id,ImGuiTreeNodeFlags flags,const char* fmt,va_list args)
 {
@@ -1020,11 +1046,19 @@ CIMGUI_API float igGetTreeNodeToLabelSpacing()
 }
 CIMGUI_API bool igCollapsingHeader_TreeNodeFlags(const char* label,ImGuiTreeNodeFlags flags)
 {
-    return ImGui::CollapsingHeader(label,flags);
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        label != nullptr ? label : "",
+        [label, flags]() { return ImGui::CollapsingHeader(label,flags); },
+        (flags & ImGuiTreeNodeFlags_Leaf) == 0);
 }
 CIMGUI_API bool igCollapsingHeader_BoolPtr(const char* label,bool* p_visible,ImGuiTreeNodeFlags flags)
 {
-    return ImGui::CollapsingHeader(label,p_visible,flags);
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        label != nullptr ? label : "",
+        [label, p_visible, flags]() { return ImGui::CollapsingHeader(label,p_visible,flags); },
+        (flags & ImGuiTreeNodeFlags_Leaf) == 0);
 }
 CIMGUI_API void igSetNextItemOpen(bool is_open,ImGuiCond cond)
 {

--- a/src/cimgui/cimgui_ref.cpp
+++ b/src/cimgui/cimgui_ref.cpp
@@ -1,0 +1,93 @@
+#include <imgui.h>
+#ifdef IMGUI_ENABLE_FREETYPE
+#include <misc/freetype/imgui_freetype.h>
+#endif
+#include <imgui_internal.h>
+#include "cimgui.h"
+#include "utility/PersistentTreeState.hpp"
+
+CIMGUI_API bool igTreeNode_Str(const char* label)
+{
+    const auto* id = label != nullptr ? label : "";
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        id,
+        [label]() { return ImGui::TreeNode(label); });
+}
+CIMGUI_API bool igTreeNode_StrStr(const char* str_id,const char* fmt,...)
+{
+    va_list args;
+    va_start(args, fmt);
+    bool ret = reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        str_id != nullptr ? str_id : "",
+        [&]() { return ImGui::TreeNodeV(str_id,fmt,args); });
+    va_end(args);
+    return ret;
+}
+#ifdef CIMGUI_VARGS0
+CIMGUI_API bool igTreeNode_StrStr0(const char* str_id,const char* fmt)
+{
+    return igTreeNode_StrStr(str_id,fmt);
+}
+#endif
+CIMGUI_API bool igTreeNodeV_Str(const char* str_id,const char* fmt,va_list args)
+{
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        str_id != nullptr ? str_id : "",
+        [&]() { return ImGui::TreeNodeV(str_id,fmt,args); });
+}
+CIMGUI_API bool igTreeNodeEx_Str(const char* label,ImGuiTreeNodeFlags flags)
+{
+    const bool can_persist = (flags & ImGuiTreeNodeFlags_Leaf) == 0;
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        label != nullptr ? label : "",
+        [label, flags]() { return ImGui::TreeNodeEx(label,flags); },
+        can_persist);
+}
+CIMGUI_API bool igTreeNodeEx_StrStr(const char* str_id,ImGuiTreeNodeFlags flags,const char* fmt,...)
+{
+    va_list args;
+    va_start(args, fmt);
+    const bool can_persist = (flags & ImGuiTreeNodeFlags_Leaf) == 0;
+    bool ret = reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        str_id != nullptr ? str_id : "",
+        [&]() { return ImGui::TreeNodeExV(str_id,flags,fmt,args); },
+        can_persist);
+    va_end(args);
+    return ret;
+}
+#ifdef CIMGUI_VARGS0
+CIMGUI_API bool igTreeNodeEx_StrStr0(const char* str_id,ImGuiTreeNodeFlags flags,const char* fmt)
+{
+    return igTreeNodeEx_StrStr(str_id,flags,fmt);
+}
+#endif
+CIMGUI_API bool igTreeNodeExV_Str(const char* str_id,ImGuiTreeNodeFlags flags,const char* fmt,va_list args)
+{
+    const bool can_persist = (flags & ImGuiTreeNodeFlags_Leaf) == 0;
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        str_id != nullptr ? str_id : "",
+        [&]() { return ImGui::TreeNodeExV(str_id,flags,fmt,args); },
+        can_persist);
+}
+CIMGUI_API bool igCollapsingHeader_TreeNodeFlags(const char* label,ImGuiTreeNodeFlags flags)
+{
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        label != nullptr ? label : "",
+        [label, flags]() { return ImGui::CollapsingHeader(label,flags); },
+        (flags & ImGuiTreeNodeFlags_Leaf) == 0);
+}
+CIMGUI_API bool igCollapsingHeader_BoolPtr(const char* label,bool* p_visible,ImGuiTreeNodeFlags flags)
+{
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::CImGui,
+        label != nullptr ? label : "",
+        [label, p_visible, flags]() { return ImGui::CollapsingHeader(label,p_visible,flags); },
+        (flags & ImGuiTreeNodeFlags_Leaf) == 0);
+}

--- a/src/mods/APIProxy.cpp
+++ b/src/mods/APIProxy.cpp
@@ -1,4 +1,5 @@
 #include "utility/FunctionHookMinHook.hpp"
+#include "utility/PersistentTreeState.hpp"
 #include "utility/String.hpp"
 
 #include "ScriptRunner.hpp"
@@ -225,6 +226,12 @@ void APIProxy::on_draw_ui() {
             } catch(...) {
                 spdlog::error("[APIProxy] Exception occurred in on_imgui_draw_ui callback; one of the plugins has an error.");
             }
+        }
+
+        if (reframework::ui::has_seen_tree_state_item(
+                reframework::ui::TreeStateSource::CImGui,
+                "REFramework.NET Script Generated UI")) {
+            reframework::ui::finish_tree_state_initialization(reframework::ui::TreeStateSource::CImGui);
         }
     }
 }

--- a/src/mods/APIProxy.cpp
+++ b/src/mods/APIProxy.cpp
@@ -227,12 +227,6 @@ void APIProxy::on_draw_ui() {
                 spdlog::error("[APIProxy] Exception occurred in on_imgui_draw_ui callback; one of the plugins has an error.");
             }
         }
-
-        if (reframework::ui::has_seen_tree_state_item(
-                reframework::ui::TreeStateSource::CImGui,
-                "REFramework.NET Script Generated UI")) {
-            reframework::ui::finish_tree_state_initialization(reframework::ui::TreeStateSource::CImGui);
-        }
     }
 }
 

--- a/src/mods/REFrameworkConfig.cpp
+++ b/src/mods/REFrameworkConfig.cpp
@@ -55,11 +55,11 @@ void REFrameworkConfig::on_draw_ui() {
     if (m_font_size->draw("Font Size")) {
         g_framework->set_font_size(m_font_size->value());
 
-        const auto monitor_size = g_framework->get_main_window_monitor_size();
-        if (monitor_size.x > 0.0f && monitor_size.y > 0.0f) {
+        const auto display_size = g_framework->get_main_window_display_size();
+        if (display_size.x > 0.0f && display_size.y > 0.0f) {
             set_ui_layout_state(
-                static_cast<int32_t>(monitor_size.x),
-                static_cast<int32_t>(monitor_size.y),
+                static_cast<int32_t>(display_size.x),
+                static_cast<int32_t>(display_size.y),
                 g_framework->get_font_size());
         }
 

--- a/src/mods/REFrameworkConfig.cpp
+++ b/src/mods/REFrameworkConfig.cpp
@@ -54,6 +54,15 @@ void REFrameworkConfig::on_draw_ui() {
 
     if (m_font_size->draw("Font Size")) {
         g_framework->set_font_size(m_font_size->value());
+
+        const auto monitor_size = g_framework->get_main_window_monitor_size();
+        if (monitor_size.x > 0.0f && monitor_size.y > 0.0f) {
+            set_ui_layout_state(
+                static_cast<int32_t>(monitor_size.x),
+                static_cast<int32_t>(monitor_size.y),
+                g_framework->get_font_size());
+        }
+
         changed = true;
     }
 
@@ -80,7 +89,10 @@ void REFrameworkConfig::on_config_load(const utility::Config& cfg) {
     }
     
     g_framework->set_font(m_font_file->value());
-    g_framework->set_font_size(m_font_size->value());
+    const auto saved_font_size = m_ui_font_size->value() > 0.0f
+        ? m_ui_font_size->value()
+        : static_cast<float>(m_font_size->value());
+    g_framework->set_font_size_for_display(saved_font_size, static_cast<float>(m_ui_monitor_height->value()));
 }
 
 void REFrameworkConfig::on_config_save(utility::Config& cfg) {

--- a/src/mods/REFrameworkConfig.hpp
+++ b/src/mods/REFrameworkConfig.hpp
@@ -40,6 +40,10 @@ public:
         m_font_size->value() = static_cast<int32_t>(font_size + 0.5f);
     }
 
+    bool has_ui_layout_state() const {
+        return m_ui_monitor_width->value() > 0 && m_ui_monitor_height->value() > 0;
+    }
+
 private:
     ModKey::Ptr m_menu_key{ ModKey::create(generate_name("MenuKey_V2"), VK_INSERT) };
     ModToggle::Ptr m_menu_open{ ModToggle::create(generate_name("MenuOpen"), true) };

--- a/src/mods/REFrameworkConfig.hpp
+++ b/src/mods/REFrameworkConfig.hpp
@@ -5,6 +5,9 @@
 class REFrameworkConfig : public Mod {
 public:
     static inline constexpr std::string_view REFRAMEWORK_CONFIG_NAME{ "re2_fw_config.txt" };
+    static inline constexpr std::string_view UI_MONITOR_WIDTH_CONFIG_NAME{ "REFrameworkConfig_UIMonitorWidth" };
+    static inline constexpr std::string_view UI_MONITOR_HEIGHT_CONFIG_NAME{ "REFrameworkConfig_UIMonitorHeight" };
+    static inline constexpr std::string_view UI_FONT_SIZE_CONFIG_NAME{ "REFrameworkConfig_UIFontSize" };
     static std::shared_ptr<REFrameworkConfig>& get();
 
 public:
@@ -30,6 +33,13 @@ public:
         return m_always_show_cursor->value();
     }
 
+    void set_ui_layout_state(int32_t width, int32_t height, float font_size) {
+        m_ui_monitor_width->value() = width;
+        m_ui_monitor_height->value() = height;
+        m_ui_font_size->value() = font_size;
+        m_font_size->value() = static_cast<int32_t>(font_size + 0.5f);
+    }
+
 private:
     ModKey::Ptr m_menu_key{ ModKey::create(generate_name("MenuKey_V2"), VK_INSERT) };
     ModToggle::Ptr m_menu_open{ ModToggle::create(generate_name("MenuOpen"), true) };
@@ -41,6 +51,9 @@ private:
 #endif
     ModKey::Ptr m_show_cursor_key{ ModKey::create(generate_name("ShowCursorKey")) };
     ModInt32::Ptr m_font_size{ModInt32::create(generate_name("FontSize"), 16)};
+    ModInt32::Ptr m_ui_monitor_width{ModInt32::create(UI_MONITOR_WIDTH_CONFIG_NAME, 0)};
+    ModInt32::Ptr m_ui_monitor_height{ModInt32::create(UI_MONITOR_HEIGHT_CONFIG_NAME, 0)};
+    ModFloat::Ptr m_ui_font_size{ModFloat::create(UI_FONT_SIZE_CONFIG_NAME, 0.0f)};
     std::vector<std::string> fonts{};
     ModComboString::Ptr m_font_file{};
 
@@ -51,5 +64,8 @@ private:
         *m_always_show_cursor,
         *m_show_cursor_key,
         *m_font_size,
+        *m_ui_monitor_width,
+        *m_ui_monitor_height,
+        *m_ui_font_size,
     };
 };

--- a/src/mods/ScriptRunner.cpp
+++ b/src/mods/ScriptRunner.cpp
@@ -14,6 +14,7 @@
 #include "sdk/SF6Utility.hpp"
 
 #include "utility/String.hpp"
+#include "utility/PersistentTreeState.hpp"
 #include <utility/ScopeGuard.hpp>
 
 #include "Mods.hpp"
@@ -1199,16 +1200,23 @@ void ScriptRunner::on_draw_ui() {
     if (!m_last_online_match_state) { 
         std::scoped_lock _{ m_access_mutex };
 
+        const bool scripts_initialized = !m_states.empty();
 
-        if (ImGui::CollapsingHeader("Script Generated UI")) {
-            if (m_states.empty()) {
-                return;
-            }
-            for (auto& state : m_states) {
-                state->on_draw_ui();
+        if (reframework::ui::persistent_tree_item(
+                reframework::ui::TreeStateSource::Native,
+                "Script Generated UI",
+                []() { return ImGui::CollapsingHeader("Script Generated UI"); })) {
+            if (scripts_initialized) {
+                for (auto& state : m_states) {
+                    state->on_draw_ui();
+                }
             }
         }
-            
+
+        if (scripts_initialized) {
+            reframework::ui::finish_tree_state_initialization(reframework::ui::TreeStateSource::Native);
+            reframework::ui::finish_tree_state_initialization(reframework::ui::TreeStateSource::Lua);
+        }
     }
 }
 

--- a/src/mods/ScriptRunner.cpp
+++ b/src/mods/ScriptRunner.cpp
@@ -1212,11 +1212,6 @@ void ScriptRunner::on_draw_ui() {
                 }
             }
         }
-
-        if (scripts_initialized) {
-            reframework::ui::finish_tree_state_initialization(reframework::ui::TreeStateSource::Native);
-            reframework::ui::finish_tree_state_initialization(reframework::ui::TreeStateSource::Lua);
-        }
     }
 }
 

--- a/src/mods/bindings/ImGui.cpp
+++ b/src/mods/bindings/ImGui.cpp
@@ -6,6 +6,7 @@
 #include "sdk/SceneManager.hpp"
 #include "REFramework.hpp"
 #include "utility/ImGui.hpp"
+#include "utility/PersistentTreeState.hpp"
 
 #include "ImGui.hpp"
 
@@ -386,7 +387,10 @@ bool tree_node(const char* label) {
         label = "";
     }
 
-    return ImGui::TreeNode(label);
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::Lua,
+        label,
+        [label]() { return ImGui::TreeNode(label); });
 }
 
 bool tree_node_ptr_id(const void* id, const char* label) {
@@ -402,7 +406,10 @@ bool tree_node_str_id(const char* id, const char* label) {
         label = "";
     }
 
-    return ImGui::TreeNode(id, label);
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::Lua,
+        id != nullptr ? id : "",
+        [id, label]() { return ImGui::TreeNode(id, label); });
 }
 
 void tree_pop() {
@@ -536,7 +543,14 @@ void new_line() {
 }
 
 bool collapsing_header(const char* name) {
-    return ImGui::CollapsingHeader(name);
+    if (name == nullptr) {
+        name = "";
+    }
+
+    return reframework::ui::persistent_tree_item(
+        reframework::ui::TreeStateSource::Lua,
+        name,
+        [name]() { return ImGui::CollapsingHeader(name); });
 }
 
 int load_font(sol::object filepath_obj, float size) {

--- a/src/utility/PersistentTreeState.hpp
+++ b/src/utility/PersistentTreeState.hpp
@@ -1,20 +1,17 @@
 #pragma once
 
-#include <algorithm>
 #include <charconv>
 #include <cstdint>
 #include <filesystem>
-#include <fstream>
-#include <iomanip>
 #include <string>
 #include <string_view>
 #include <unordered_set>
-#include <vector>
 
 #include <imgui.h>
 #include <imgui_internal.h>
 
 #include <utility/String.hpp>
+#include <utility/Config.hpp>
 
 namespace reframework::ui {
 enum class TreeStateSource : uint8_t {
@@ -25,6 +22,10 @@ enum class TreeStateSource : uint8_t {
 };
 
 namespace detail {
+static inline constexpr int32_t CONFIG_VERSION{1};
+static inline constexpr std::string_view CONFIG_VERSION_KEY{"Version"};
+static inline constexpr std::string_view OPEN_NODE_PREFIX{"OpenNode_"};
+
 struct TreeState {
     std::unordered_set<uint64_t> open_nodes{};
     std::unordered_set<uint64_t> initialized_nodes{};
@@ -39,46 +40,19 @@ inline uint64_t make_key(TreeStateSource source, uint64_t component) {
     return (component & 0x00FFFFFFFFFFFFFFULL) | (static_cast<uint64_t>(source) << 56);
 }
 
-inline void read_line(std::string_view line) {
-    static constexpr std::string_view PREFIX{"Node="};
-
-    if (!line.starts_with(PREFIX)) {
-        return;
-    }
-
-    uint64_t key{};
-    const auto first = line.data() + PREFIX.size();
-    const auto last = line.data() + line.size();
-    const auto result = std::from_chars(first, last, key, 16);
-
-    if (result.ec == std::errc{} && result.ptr == last) {
-        const auto source_value = static_cast<uint8_t>(key >> 56);
-
-        if (source_value < static_cast<uint8_t>(TreeStateSource::Count)) {
-            g_tree_state.open_nodes.insert(key);
-        }
-    }
-}
-
 inline void save_open_nodes() {
     if (g_tree_state.settings_path.empty()) {
         return;
     }
 
-    std::vector<uint64_t> sorted_nodes{g_tree_state.open_nodes.begin(), g_tree_state.open_nodes.end()};
-    std::ranges::sort(sorted_nodes);
+    utility::Config config{};
+    config.set<int32_t>(CONFIG_VERSION_KEY.data(), CONFIG_VERSION);
 
-    std::ofstream output{g_tree_state.settings_path, std::ios::trunc};
-
-    if (!output) {
-        return;
+    for (const auto key : g_tree_state.open_nodes) {
+        config.set<bool>(std::string{OPEN_NODE_PREFIX} + std::to_string(key), true);
     }
 
-    output << "[Open]\nVersion=1\n";
-
-    for (const auto key : sorted_nodes) {
-        output << "Node=" << std::uppercase << std::hex << std::setw(16) << std::setfill('0') << key << '\n';
-    }
+    config.save(g_tree_state.settings_path.string());
 }
 
 inline void update_open_state(uint64_t key, bool is_open) {
@@ -108,29 +82,29 @@ inline void initialize_tree_state(const std::filesystem::path& settings_path) {
     detail::g_tree_state.open_nodes.clear();
     detail::g_tree_state.initialized_nodes.clear();
 
-    std::ifstream input{settings_path};
-    std::string line{};
-    bool recognized_format{};
-    bool read_any_line{};
+    const utility::Config config{settings_path.string()};
 
-    while (std::getline(input, line)) {
-        read_any_line = true;
-
-        if (!line.empty() && line.back() == '\r') {
-            line.pop_back();
-        }
-
-        if (line == "Version=1") {
-            recognized_format = true;
-        } else if (recognized_format) {
-            detail::read_line(line);
-        }
+    if (config.get<int32_t>(detail::CONFIG_VERSION_KEY.data()).value_or(0) != detail::CONFIG_VERSION) {
+        return;
     }
 
-    input.close();
+    for (const auto& [name, value] : config.get_key_values()) {
+        if (!name.starts_with(detail::OPEN_NODE_PREFIX) || value != "true") {
+            continue;
+        }
 
-    if (read_any_line && !recognized_format) {
-        detail::save_open_nodes();
+        uint64_t key{};
+        const auto first = name.data() + detail::OPEN_NODE_PREFIX.size();
+        const auto last = name.data() + name.size();
+        const auto result = std::from_chars(first, last, key);
+
+        if (result.ec == std::errc{} && result.ptr == last) {
+            const auto source_value = static_cast<uint8_t>(key >> 56);
+
+            if (source_value < static_cast<uint8_t>(TreeStateSource::Count)) {
+                detail::g_tree_state.open_nodes.insert(key);
+            }
+        }
     }
 }
 

--- a/src/utility/PersistentTreeState.hpp
+++ b/src/utility/PersistentTreeState.hpp
@@ -10,7 +10,6 @@
 #include <imgui.h>
 #include <imgui_internal.h>
 
-#include <utility/String.hpp>
 #include <utility/Config.hpp>
 
 namespace reframework::ui {
@@ -114,7 +113,9 @@ bool persistent_tree_item(
     std::string_view stable_id,
     DrawFunction&& draw_function,
     bool can_persist = true) {
-    const auto component = utility::hash(stable_id);
+    auto* window = ImGui::GetCurrentWindow();
+    const auto component = static_cast<uint64_t>(
+        window->GetID(stable_id.data(), stable_id.data() + stable_id.size()));
     const auto key = detail::make_key(source, component);
 
     if (can_persist && detail::g_tree_state.initialized_nodes.insert(key).second) {

--- a/src/utility/PersistentTreeState.hpp
+++ b/src/utility/PersistentTreeState.hpp
@@ -14,6 +14,8 @@
 #include <imgui.h>
 #include <imgui_internal.h>
 
+#include <utility/String.hpp>
+
 namespace reframework::ui {
 enum class TreeStateSource : uint8_t {
     Native,
@@ -23,9 +25,6 @@ enum class TreeStateSource : uint8_t {
 };
 
 namespace detail {
-static inline constexpr uint64_t FNV_OFFSET_BASIS{14695981039346656037ull};
-static inline constexpr uint64_t FNV_PRIME{1099511628211ull};
-
 struct TreeState {
     std::unordered_set<uint64_t> open_nodes{};
     std::unordered_set<uint64_t> initialized_nodes{};
@@ -36,34 +35,8 @@ struct TreeState {
 
 inline TreeState g_tree_state{};
 
-inline void hash_bytes(uint64_t& hash, const void* data, size_t size) {
-    const auto* bytes = static_cast<const uint8_t*>(data);
-
-    for (size_t i = 0; i < size; ++i) {
-        hash ^= bytes[i];
-        hash *= FNV_PRIME;
-    }
-
-    hash ^= 0xff;
-    hash *= FNV_PRIME;
-}
-
-inline void hash_string(uint64_t& hash, std::string_view value) {
-    hash_bytes(hash, value.data(), value.size());
-}
-
-inline uint64_t string_component(std::string_view value) {
-    auto hash = FNV_OFFSET_BASIS;
-    hash_string(hash, value);
-    return hash;
-}
-
 inline uint64_t make_key(TreeStateSource source, uint64_t component) {
-    auto hash = FNV_OFFSET_BASIS;
-    const auto source_value = static_cast<uint8_t>(source);
-    hash_bytes(hash, &source_value, sizeof(source_value));
-    hash_bytes(hash, &component, sizeof(component));
-    return (hash & 0x00ffffffffffffffull) | (static_cast<uint64_t>(source_value) << 56);
+    return (component & 0x00FFFFFFFFFFFFFFULL) | (static_cast<uint64_t>(source) << 56);
 }
 
 inline void read_line(std::string_view line) {
@@ -167,7 +140,7 @@ bool persistent_tree_item(
     std::string_view stable_id,
     DrawFunction&& draw_function,
     bool can_persist = true) {
-    const auto component = detail::string_component(stable_id);
+    const auto component = utility::hash(stable_id);
     const auto key = detail::make_key(source, component);
 
     if (can_persist && detail::g_tree_state.initialized_nodes.insert(key).second) {

--- a/src/utility/PersistentTreeState.hpp
+++ b/src/utility/PersistentTreeState.hpp
@@ -1,0 +1,226 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+#include <imgui.h>
+#include <imgui_internal.h>
+
+namespace reframework::ui {
+enum class TreeStateSource : uint8_t {
+    Native,
+    Lua,
+    CImGui,
+    Count,
+};
+
+namespace detail {
+static inline constexpr uint64_t FNV_OFFSET_BASIS{14695981039346656037ull};
+static inline constexpr uint64_t FNV_PRIME{1099511628211ull};
+
+struct TreeState {
+    std::unordered_set<uint64_t> open_nodes{};
+    std::unordered_set<uint64_t> initialized_nodes{};
+    std::array<std::unordered_set<uint64_t>, static_cast<size_t>(TreeStateSource::Count)> unseen_loaded_nodes{};
+    std::array<bool, static_cast<size_t>(TreeStateSource::Count)> initialization_finished{};
+    std::filesystem::path settings_path{};
+    bool loaded{};
+};
+
+inline TreeState g_tree_state{};
+
+inline void hash_bytes(uint64_t& hash, const void* data, size_t size) {
+    const auto* bytes = static_cast<const uint8_t*>(data);
+
+    for (size_t i = 0; i < size; ++i) {
+        hash ^= bytes[i];
+        hash *= FNV_PRIME;
+    }
+
+    hash ^= 0xff;
+    hash *= FNV_PRIME;
+}
+
+inline void hash_string(uint64_t& hash, std::string_view value) {
+    hash_bytes(hash, value.data(), value.size());
+}
+
+inline uint64_t string_component(std::string_view value) {
+    auto hash = FNV_OFFSET_BASIS;
+    hash_string(hash, value);
+    return hash;
+}
+
+inline uint64_t make_key(TreeStateSource source, uint64_t component) {
+    auto hash = FNV_OFFSET_BASIS;
+    const auto source_value = static_cast<uint8_t>(source);
+    hash_bytes(hash, &source_value, sizeof(source_value));
+    hash_bytes(hash, &component, sizeof(component));
+    return (hash & 0x00ffffffffffffffull) | (static_cast<uint64_t>(source_value) << 56);
+}
+
+inline void read_line(std::string_view line) {
+    static constexpr std::string_view PREFIX{"Node="};
+
+    if (!line.starts_with(PREFIX)) {
+        return;
+    }
+
+    uint64_t key{};
+    const auto first = line.data() + PREFIX.size();
+    const auto last = line.data() + line.size();
+    const auto result = std::from_chars(first, last, key, 16);
+
+    if (result.ec == std::errc{} && result.ptr == last) {
+        const auto source_value = static_cast<uint8_t>(key >> 56);
+
+        if (source_value < static_cast<uint8_t>(TreeStateSource::Count)) {
+            g_tree_state.open_nodes.insert(key);
+            g_tree_state.unseen_loaded_nodes[source_value].insert(key);
+        }
+    }
+}
+
+inline void save_open_nodes() {
+    if (g_tree_state.settings_path.empty()) {
+        return;
+    }
+
+    std::vector<uint64_t> sorted_nodes{g_tree_state.open_nodes.begin(), g_tree_state.open_nodes.end()};
+    std::ranges::sort(sorted_nodes);
+
+    std::ofstream output{g_tree_state.settings_path, std::ios::trunc};
+
+    if (!output) {
+        return;
+    }
+
+    output << "[Open]\nVersion=1\n";
+
+    for (const auto key : sorted_nodes) {
+        output << "Node=" << std::uppercase << std::hex << std::setw(16) << std::setfill('0') << key << '\n';
+    }
+}
+
+inline void update_open_state(uint64_t key, bool is_open) {
+    const bool changed = is_open
+        ? g_tree_state.open_nodes.insert(key).second
+        : g_tree_state.open_nodes.erase(key) > 0;
+
+    if (changed) {
+        save_open_nodes();
+    }
+}
+} // namespace detail
+
+inline void initialize_tree_state(const std::filesystem::path& settings_path) {
+    if (detail::g_tree_state.loaded) {
+        return;
+    }
+
+    detail::g_tree_state.loaded = true;
+    detail::g_tree_state.settings_path = settings_path;
+    detail::g_tree_state.open_nodes.clear();
+    detail::g_tree_state.initialized_nodes.clear();
+
+    for (auto& unseen_nodes : detail::g_tree_state.unseen_loaded_nodes) {
+        unseen_nodes.clear();
+    }
+
+    detail::g_tree_state.initialization_finished.fill(false);
+
+    std::ifstream input{settings_path};
+    std::string line{};
+    bool recognized_format{};
+    bool read_any_line{};
+
+    while (std::getline(input, line)) {
+        read_any_line = true;
+
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+
+        if (line == "Version=1") {
+            recognized_format = true;
+        } else if (recognized_format) {
+            detail::read_line(line);
+        }
+    }
+
+    input.close();
+
+    if (read_any_line && !recognized_format) {
+        detail::save_open_nodes();
+    }
+}
+
+inline bool has_seen_tree_state_item(TreeStateSource source, std::string_view stable_id) {
+    const auto key = detail::make_key(source, detail::string_component(stable_id));
+    return detail::g_tree_state.initialized_nodes.contains(key);
+}
+
+inline void finish_tree_state_initialization(TreeStateSource source) {
+    const auto source_index = static_cast<size_t>(source);
+
+    if (detail::g_tree_state.initialization_finished[source_index]) {
+        return;
+    }
+
+    detail::g_tree_state.initialization_finished[source_index] = true;
+    auto& unseen_nodes = detail::g_tree_state.unseen_loaded_nodes[source_index];
+    bool changed{};
+
+    for (const auto key : unseen_nodes) {
+        changed = detail::g_tree_state.open_nodes.erase(key) > 0 || changed;
+    }
+
+    unseen_nodes.clear();
+
+    if (changed) {
+        detail::save_open_nodes();
+    }
+}
+
+template <typename DrawFunction>
+bool persistent_tree_item(
+    TreeStateSource source,
+    std::string_view stable_id,
+    DrawFunction&& draw_function,
+    bool can_persist = true) {
+    const auto component = detail::string_component(stable_id);
+    const auto key = detail::make_key(source, component);
+    const auto source_index = static_cast<size_t>(source);
+
+    if (can_persist) {
+        detail::g_tree_state.unseen_loaded_nodes[source_index].erase(key);
+
+        if (!detail::g_tree_state.initialization_finished[source_index] &&
+            detail::g_tree_state.initialized_nodes.insert(key).second) {
+            const auto& next_item_data = ImGui::GetCurrentContext()->NextItemData;
+            const bool caller_supplied_open_state = (next_item_data.HasFlags & ImGuiNextItemDataFlags_HasOpen) != 0;
+
+            if (!caller_supplied_open_state) {
+                ImGui::SetNextItemOpen(detail::g_tree_state.open_nodes.contains(key), ImGuiCond_Always);
+            }
+        }
+    }
+
+    const bool is_open = draw_function();
+
+    if (can_persist && ImGui::IsItemToggledOpen()) {
+        detail::update_open_state(key, is_open);
+    }
+
+    return is_open;
+}
+} // namespace reframework::ui

--- a/src/utility/PersistentTreeState.hpp
+++ b/src/utility/PersistentTreeState.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
 #include <charconv>
 #include <cstdint>
 #include <filesystem>
@@ -30,9 +29,8 @@ static inline constexpr uint64_t FNV_PRIME{1099511628211ull};
 struct TreeState {
     std::unordered_set<uint64_t> open_nodes{};
     std::unordered_set<uint64_t> initialized_nodes{};
-    std::array<std::unordered_set<uint64_t>, static_cast<size_t>(TreeStateSource::Count)> unseen_loaded_nodes{};
-    std::array<bool, static_cast<size_t>(TreeStateSource::Count)> initialization_finished{};
     std::filesystem::path settings_path{};
+    ImGuiContext* context{};
     bool loaded{};
 };
 
@@ -85,7 +83,6 @@ inline void read_line(std::string_view line) {
 
         if (source_value < static_cast<uint8_t>(TreeStateSource::Count)) {
             g_tree_state.open_nodes.insert(key);
-            g_tree_state.unseen_loaded_nodes[source_value].insert(key);
         }
     }
 }
@@ -124,19 +121,19 @@ inline void update_open_state(uint64_t key, bool is_open) {
 
 inline void initialize_tree_state(const std::filesystem::path& settings_path) {
     if (detail::g_tree_state.loaded) {
+        if (detail::g_tree_state.context != ImGui::GetCurrentContext()) {
+            detail::g_tree_state.context = ImGui::GetCurrentContext();
+            detail::g_tree_state.initialized_nodes.clear();
+        }
+
         return;
     }
 
     detail::g_tree_state.loaded = true;
     detail::g_tree_state.settings_path = settings_path;
+    detail::g_tree_state.context = ImGui::GetCurrentContext();
     detail::g_tree_state.open_nodes.clear();
     detail::g_tree_state.initialized_nodes.clear();
-
-    for (auto& unseen_nodes : detail::g_tree_state.unseen_loaded_nodes) {
-        unseen_nodes.clear();
-    }
-
-    detail::g_tree_state.initialization_finished.fill(false);
 
     std::ifstream input{settings_path};
     std::string line{};
@@ -164,33 +161,6 @@ inline void initialize_tree_state(const std::filesystem::path& settings_path) {
     }
 }
 
-inline bool has_seen_tree_state_item(TreeStateSource source, std::string_view stable_id) {
-    const auto key = detail::make_key(source, detail::string_component(stable_id));
-    return detail::g_tree_state.initialized_nodes.contains(key);
-}
-
-inline void finish_tree_state_initialization(TreeStateSource source) {
-    const auto source_index = static_cast<size_t>(source);
-
-    if (detail::g_tree_state.initialization_finished[source_index]) {
-        return;
-    }
-
-    detail::g_tree_state.initialization_finished[source_index] = true;
-    auto& unseen_nodes = detail::g_tree_state.unseen_loaded_nodes[source_index];
-    bool changed{};
-
-    for (const auto key : unseen_nodes) {
-        changed = detail::g_tree_state.open_nodes.erase(key) > 0 || changed;
-    }
-
-    unseen_nodes.clear();
-
-    if (changed) {
-        detail::save_open_nodes();
-    }
-}
-
 template <typename DrawFunction>
 bool persistent_tree_item(
     TreeStateSource source,
@@ -199,19 +169,13 @@ bool persistent_tree_item(
     bool can_persist = true) {
     const auto component = detail::string_component(stable_id);
     const auto key = detail::make_key(source, component);
-    const auto source_index = static_cast<size_t>(source);
 
-    if (can_persist) {
-        detail::g_tree_state.unseen_loaded_nodes[source_index].erase(key);
+    if (can_persist && detail::g_tree_state.initialized_nodes.insert(key).second) {
+        const auto& next_item_data = ImGui::GetCurrentContext()->NextItemData;
+        const bool caller_supplied_open_state = (next_item_data.HasFlags & ImGuiNextItemDataFlags_HasOpen) != 0;
 
-        if (!detail::g_tree_state.initialization_finished[source_index] &&
-            detail::g_tree_state.initialized_nodes.insert(key).second) {
-            const auto& next_item_data = ImGui::GetCurrentContext()->NextItemData;
-            const bool caller_supplied_open_state = (next_item_data.HasFlags & ImGuiNextItemDataFlags_HasOpen) != 0;
-
-            if (!caller_supplied_open_state) {
-                ImGui::SetNextItemOpen(detail::g_tree_state.open_nodes.contains(key), ImGuiCond_Always);
-            }
+        if (!caller_supplied_open_state) {
+            ImGui::SetNextItemOpen(detail::g_tree_state.open_nodes.contains(key), ImGuiCond_Always);
         }
     }
 


### PR DESCRIPTION
-Relative Position and Size are now maintained
-Changing display resolution while the game is active now updates the size/position of Ref UI to maintain relative size/location 
-Fix for issue #1540 (Saved Window Size/Position Will Sometimes Not Be in The Correct Position) 
-It is impossible to completely lose ref ui outside of display bounds -Font size adjusts relatively as well
-Imgui UI is now saved on close (this is/was independent of the ref config).

Passed build.