### PR TITLE
Lua: Fix on_pre_gui_draw_element ignoring a false return

### DIFF
--- a/src/mods/ScriptRunner.cpp
+++ b/src/mods/ScriptRunner.cpp
@@ -663,7 +663,7 @@ bool ScriptState::on_pre_gui_draw_element(REComponent* gui_element, void* contex
 
         auto guard = m_pre_gui_draw_element_fns.acquire_iteration();
         for (auto& fn : m_pre_gui_draw_element_fns.get()) {
-            if (auto result = handle_protected_result(fn(gui_element, context))) {
+            if (auto result = handle_protected_result(fn(gui_element, context)); result.valid()) {
                 auto result_obj = result.get<sol::object>();
 
                 if (!result_obj.is<sol::nil_t>() && result_obj.is<bool>() && result_obj.as<bool>() == false) {


### PR DESCRIPTION
re.on_pre_gui_draw_element returning false stopped hiding the element as of #1503.

protected_function_result has no explicit operator bool, so proxy_base's templated operator T() matches and the if compiles to `result.get<bool>()`. That checks the script's return value instead of whether the call worked, so a script returning false to hide an element skips the block and any_false never gets set.

Tested on RE9: a script vetoing every gui element has no effect on 684ca773. With this fix it works again - the whole HUD disappears.