### PR TITLE
SDK (RE4): Fix VR multipass crash on 1.5.9.0

### DIFF
--- a/shared/sdk/Renderer.hpp
+++ b/shared/sdk/Renderer.hpp
@@ -93,10 +93,11 @@ public:
 
 private:
     // desc sits at sizeof(RenderResource) + one void* for older games, +0x18 for TDB >= 73 / SF6.
+    // RE4 moved to the SF6 layout in its 1.5.9.0 update (2026-03-31).
     static inline uintptr_t get_s_desc_offset() {
         const auto& gi = sdk::GameIdentity::get();
         const auto v = gi.tdb_ver();
-        if (v >= 73 || gi.is_sf6()) {
+        if (v >= 73 || gi.is_sf6() || gi.is_re4()) {
             return RenderResource::get_runtime_size() + 0x18;
         }
         return RenderResource::get_runtime_size() + sizeof(void*);
@@ -107,7 +108,8 @@ private:
         const auto v = gi.tdb_ver();
         if (v >= 73) return 0xE0;
         if (v >= 71) {
-            if (gi.is_sf6()) return 0xB8;
+            // RE4 1.5.9.0 matches SF6 here; it used to be 0xA0.
+            if (gi.is_sf6() || gi.is_re4()) return 0xB8;
             if (gi.is_mhrise()) return 0x98; // WHAT THE HECK!!!
             return 0xA0;
         }


### PR DESCRIPTION
RE4's 2026-03-31 update (1.5.9.0) moved `via.render.Texture` to the same layout SF6 uses. The description sits at `RenderResource + 0x18` instead of `+ sizeof(void*)`, and the D3D12 resource container moved from `0xA0` to `0xB8`.

Reading them at the old offsets breaks VR multipass on RE4 — it crashes on the Capcom logo. With the upscaler enabled the game faults inside `create_texture`, called from the multipass color copy with a description read `0x10` short of where it now lives. With the upscaler disabled, and with `PDPerfPlugin.dll` removed entirely, it faults slightly further along in the same wrong layout. Both crash sites are inside the game, in one of its own worker threads, with no REFramework frame on the stack — which made this easy to mistake for an upscaler or an audio problem for a long time.

The offsets were measured rather than guessed. Pointing the existing `RenderResource` container scan at the texture reports `Found D3D12Resource container at offset b8`, and the type name at `0xB8` is `via.render.RenderResource`.

Only RE4 is affected — every other game takes exactly the branch it took before.

**Testing:** RE4 1.5.9.0 on Steam, Quest 3 over OpenXR, `VR_RenderingTechnique_V2=2`. Multipass now runs with DLSS, both eyes correct, where it previously crashed on startup. Also verified that Sequential and flatscreen are unaffected.

One known issue remains, unrelated to these offsets and present in older RE4 VR forks too: some scenery occasionally fails to appear in the cloned eye until the camera moves. It looks like occlusion culling / streaming rather than anything to do with texture layout, and I'd rather investigate that separately than bundle it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
